### PR TITLE
Feat(eos-downloader): Move CLI to RICH with optional logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,5 @@ cython_debug/
 
 # vscode
 .vscode/*
+
+*.tar.xz

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ pip install eos-downloader
 
 ```bash
 usage: eos-download [-h]
+  --version VERSION
+  [--token TOKEN]
+  [--image IMAGE]
+  [--destination DESTINATION]
+  [--eve]
+  [--noztp]
+  [--import_docker]
+  [--docker_name DOCKER_NAME]
+  [--verbose VERBOSE]
+  [--log]
 
 EOS downloader script.
 
@@ -28,8 +38,9 @@ optional arguments:
   --noztp               Option to deactivate ZTP when used with EVE-NG
   --import_docker       Option to import cEOS image to docker
   --docker_name DOCKER_NAME
-                        Docker image name to use, (default is arista/ceos)
+                        Docker image name to use
   --verbose VERBOSE     Script verbosity
+  --log                 Option to activate logging to eos-downloader.log file
 ```
 
 - Token are read from `ENV:ARISTA_TOKEN` unless you specify a specific token with CLI.
@@ -51,19 +62,48 @@ optional arguments:
 - Download vEOS-lab image and install in EVE-NG
 
 ```bash
-eos-download --image vEOS-lab --version 4.25.7M --eve --noztp
+$ eos-download --image vEOS-lab --version 4.25.7M --eve --noztp
 ```
 
 - Download Docker image
 
 ```bash
-eos-download --image cEOS --version 4.27.1F
+$ eos-download --image cEOS --version 4.27.1F
+🪐 eos-downloader is starting...
+    - Image Type: cEOS
+    - Version: 4.27.2F
+✅ Authenticated on arista.com
+🔎  Searching file cEOS-lab-4.27.2F.tar.xz
+    -> Found file at /support/download/EOS-USA/Active Releases/4.27/EOS-4.27.2F/cEOS-lab/cEOS-lab-4.27.2F.tar.xz
+💾  Downloading cEOS-lab-4.27.2F.tar.xz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • 17.1 MB/s • 451.6/451.6 MB • 0:00:19 •
+🚀  Running checksum validation
+🔎  Searching file cEOS-lab-4.27.2F.tar.xz.sha512sum
+    -> Found file at /support/download/EOS-USA/Active
+Releases/4.27/EOS-4.27.2F/cEOS-lab/cEOS-lab-4.27.2F.tar.xz.sha512sum
+💾  Downloading cEOS-lab-4.27.2F.tar.xz.sha512sum ━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • ? • 154/154 bytes • 0:00:00 •
+✅  Downloaded file is correct.
 ```
 
 - Download Docker image and install
 
 ```bash
-eos-download --image cEOS --version 4.27.1F --import_docker --docker_name test/ceos
+$ eos-download --image cEOS --version 4.27.1F --import_docker --docker_name test/ceos
+🪐 eos-downloader is starting...
+    - Image Type: cEOS
+    - Version: 4.27.2F
+✅ Authenticated on arista.com
+🔎  Searching file cEOS-lab-4.27.2F.tar.xz
+    -> Found file at /support/download/EOS-USA/Active Releases/4.27/EOS-4.27.2F/cEOS-lab/cEOS-lab-4.27.2F.tar.xz
+💾  Downloading cEOS-lab-4.27.2F.tar.xz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • 17.1 MB/s • 451.6/451.6 MB • 0:00:19 •
+🚀  Running checksum validation
+🔎  Searching file cEOS-lab-4.27.2F.tar.xz.sha512sum
+    -> Found file at /support/download/EOS-USA/Active
+Releases/4.27/EOS-4.27.2F/cEOS-lab/cEOS-lab-4.27.2F.tar.xz.sha512sum
+💾  Downloading cEOS-lab-4.27.2F.tar.xz.sha512sum ━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • ? • 154/154 bytes • 0:00:00 •
+✅  Downloaded file is correct.
+🚀 Importing image cEOS-lab-4.27.2F.tar.xz to arista/ceos:4.27.2F
+sha256:a535f5744590523861d23bc0b92a9ab0006368b0c976ca735aedac80e535d975
+✅  processing done !
 ```
 
 __Note:__ `ARISTA_TOKEN` should be set in your .profile and not set for each command. If not set, you can use `--token` knob.

--- a/bin/eos-download
+++ b/bin/eos-download
@@ -5,6 +5,7 @@ import os
 import argparse
 import eos_downloader.eos
 from loguru import logger
+from rich.console import Console
 
 ARISTA_TOKEN = os.getenv('ARISTA_TOKEN', '')
 
@@ -36,6 +37,8 @@ def read_cli():
 
     parser.add_argument('--verbose', required=False,
                         default='info', help='Script verbosity')
+    parser.add_argument('--log', required=False, action='store_true',
+                        help="Option to activate logging to eos-downloader.log file")
 
     return parser.parse_args()
 
@@ -44,8 +47,16 @@ if __name__ == '__main__':
 
     cli_options = read_cli()
 
+    console = Console()
+
     logger.remove()
-    logger.add(sys.stderr, level=str(cli_options.verbose).upper())
+    if cli_options.log:
+        logger.add("eos-downloader.log", rotation="10 MB", level=str(cli_options.verbose).upper())
+
+    console.print("🪐 [bold blue]eos-downloader[/bold blue] is starting...", )
+    console.print(f'    - Image Type: {cli_options.image}')
+    console.print(f'    - Version: {cli_options.version}')
+
 
     my_download = eos_downloader.eos.EOSDownloader(
         image=cli_options.image,
@@ -66,5 +77,5 @@ if __name__ == '__main__':
             version=cli_options.version,
             image_name=cli_options.docker_name
         )
-
+    console.print('✅  processing done !')
     sys.exit(0)

--- a/eos_downloader/download.py
+++ b/eos_downloader/download.py
@@ -1,0 +1,77 @@
+import os.path
+import sys
+import requests
+import signal
+from functools import partial
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from typing import Iterable
+from urllib.request import urlopen
+import rich
+from rich import console
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    TaskID,
+    TextColumn,
+    TransferSpeedColumn,
+    TimeElapsedColumn
+)
+
+console = rich.get_console()
+done_event = Event()
+
+
+def handle_sigint(signum, frame):
+    done_event.set()
+
+signal.signal(signal.SIGINT, handle_sigint)
+
+class DownloadProgressBar():
+    """
+    Object to manage Download process with Progress Bar from Rich
+    """
+
+    def __init__(self):
+        """
+        Class Constructor
+        """
+        self.progress = Progress(
+            TextColumn("💾  Downloading [bold blue]{task.fields[filename]}", justify="right"),
+            BarColumn(bar_width=None),
+            "[progress.percentage]{task.percentage:>3.1f}%",
+            "•",
+            TransferSpeedColumn(),
+            "•",
+            DownloadColumn(),
+            "•",
+            TimeElapsedColumn(),
+            "•",
+            console=console
+        )
+
+    def _copy_url(self, task_id: TaskID, url: str, path: str, block_size=1024) -> None:
+        """Copy data from a url to a local file."""
+        response = requests.get(url, stream=True)
+        # This will break if the response doesn't contain content length
+        self.progress.update(task_id, total=int(response.headers['Content-Length']))
+        with open(path, "wb") as dest_file:
+            self.progress.start_task(task_id)
+            for data in response.iter_content(chunk_size=block_size):
+                dest_file.write(data)
+                self.progress.update(task_id, advance=len(data))
+                if done_event.is_set():
+                    return
+        # console.print(f"Downloaded {path}")
+
+
+    def download(self, urls: Iterable[str], dest_dir: str):
+        """Download multuple files to the given directory."""
+        with self.progress:
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                for url in urls:
+                    filename = url.split("/")[-1].split('?')[0]
+                    dest_path = os.path.join(dest_dir, filename)
+                    task_id = self.progress.add_task("download", filename=filename, start=False)
+                    pool.submit(self._copy_url, task_id, url, dest_path)

--- a/eos_downloader/eos.py
+++ b/eos_downloader/eos.py
@@ -2,8 +2,12 @@
 # coding: utf-8 -*-
 
 import os
+import rich
 from loguru import logger
 from eos_downloader.object_downloader import ObjectDownloader
+from rich import console
+
+console = rich.get_console()
 
 
 class EOSDownloader(ObjectDownloader):
@@ -30,7 +34,8 @@ class EOSDownloader(ObjectDownloader):
         file_path : str
             Path where EOS image is located
         """
-        logger.info('🚀 Mounting volume to disable ZTP')
+        logger.info('Mounting volume to disable ZTP')
+        console.print('🚀 Mounting volume to disable ZTP')
         raw_folder = os.path.join(file_path, "raw")
         os.system(f"rm -rf {raw_folder}")
         os.system(f"mkdir -p {raw_folder}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests-toolbelt
 scp
 tqdm
 loguru
+rich==12.0.1


### PR DESCRIPTION
Move User Interface to [Rich](https://github.com/Textualize/rich) for better outputs

Output example:

```bash
$ python bin/eos-download --image cEOS --version 4.27.2F --import_docker

🪐 eos-downloader is starting...
    - Image Type: cEOS
    - Version: 4.27.2F
✅ Authenticated on arista.com
🔎  Searching file cEOS-lab-4.27.2F.tar.xz
    -> Found file at /support/download/EOS-USA/Active Releases/4.27/EOS-4.27.2F/cEOS-lab/cEOS-lab-4.27.2F.tar.xz
💾  Downloading cEOS-lab-4.27.2F.tar.xz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • 17.1 MB/s • 451.6/451.6 MB • 0:00:19 •
🚀  Running checksum validation
🔎  Searching file cEOS-lab-4.27.2F.tar.xz.sha512sum
    -> Found file at /support/download/EOS-USA/Active
Releases/4.27/EOS-4.27.2F/cEOS-lab/cEOS-lab-4.27.2F.tar.xz.sha512sum
💾  Downloading cEOS-lab-4.27.2F.tar.xz.sha512sum ━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • ? • 154/154 bytes • 0:00:00 •
✅  Downloaded file is correct.
🚀 Importing image cEOS-lab-4.27.2F.tar.xz to arista/ceos:4.27.2F
```

Also, add a new option to activate logging in a file besides the stdout print

```
$ python bin/eos-download --image cEOS --version 4.27.2F --import_docker --log
$ less eos-downloader.log
```