### PR TITLE
Feat: Add a CLI to download TerminAttr package like EOS images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,5 @@ cython_debug/
 *.tar.xz
 
 report.html
+
+*.xml

--- a/bin/get-arista-xml
+++ b/bin/get-arista-xml
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+import sys
+import os
+import argparse
+import eos_downloader.eos
+from loguru import logger
+from rich.console import Console
+
+ARISTA_TOKEN = os.getenv('ARISTA_TOKEN', '')
+
+def read_cli():
+    parser = argparse.ArgumentParser(description='EOS downloader script.')
+    parser.add_argument('--token', required=False,
+                        default=ARISTA_TOKEN,
+                        help='arista.com user API key - can use ENV:ARISTA_TOKEN')
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    cli_options = read_cli()
+    console = Console()
+    console.print("Download XML file from arista.com")
+
+    my_download = eos_downloader.eos.EOSDownloader(
+        image=None,
+        software=None,
+        version=None,
+        token=cli_options.token,
+        hash_method=None)
+
+    my_download.authenticate()
+    my_download.save_xml_folder(path_output='arista-software.xml')

--- a/bin/swix-download
+++ b/bin/swix-download
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+
+import sys
+import os
+import argparse
+import eos_downloader.swix
+from eos_downloader.data import DATA_MAPPING
+from loguru import logger
+from rich.console import Console
+
+ARISTA_TOKEN = os.getenv('ARISTA_TOKEN', '')
+
+
+def read_cli():
+    parser = argparse.ArgumentParser(description='EOS downloader script.')
+    parser.add_argument('--token', required=False,
+                        default=ARISTA_TOKEN,
+                        help='arista.com user API key - can use ENV:ARISTA_TOKEN')
+
+    parser.add_argument('--package', required=False,
+                        default='terminAttr', help='EOS package')
+
+    parser.add_argument('--version', required=True,
+                        default='', help='EOS version to download from website')
+
+    parser.add_argument('--destination', required=False,
+                        default=str(os.getcwd()),
+                        help='Path where to save EOS package downloaded')
+
+    parser.add_argument('--verbose', required=False,
+                        default='info', help='Script verbosity')
+
+    parser.add_argument('--log', required=False, action='store_true',
+                        help="Option to activate logging to eos-downloader.log file")
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+
+    cli_options = read_cli()
+
+    console = Console()
+
+    logger.remove()
+    if cli_options.log:
+        logger.add("eos-downloader.log", rotation="10 MB", level=str(cli_options.verbose).upper())
+
+    console.print("🪐 [bold blue]eos-downloader[/bold blue] is starting...", )
+    console.print(f'    - Image Type: {cli_options.package}')
+    console.print(f'    - Version: {cli_options.version}')
+
+    for node_name,node in DATA_MAPPING['extensions'].items():
+        if node['alias'] == cli_options.package:
+            console.print(node_name)
+            my_download = eos_downloader.swix.SWIXDownloader(
+                image=node_name,
+                software='extensions',
+                version=cli_options.version,
+                token=cli_options.token,
+                hash_method='md5sum')
+
+            my_download.authenticate()
+            my_download.download_local(file_path=cli_options.destination, checksum=True)
+
+    console.print('✅  processing done !')
+    sys.exit(0)

--- a/eos_downloader/data.py
+++ b/eos_downloader/data.py
@@ -3,6 +3,22 @@
 
 # [platform][image][version]
 DATA_MAPPING = {
+    "extensions": {
+        "Streaming Telemetry Agent": {
+            "extension": "-1.swix",
+            "prepend": "TerminAttr",
+            "folder_level": 0,
+            "alias": "TerminAttr",
+            "filename": 'TerminAttr-'
+        },
+         "Splunk": {
+            "extension": ".swix",
+            "prepend": "Splunk",
+            "folder_level": 0,
+            "alias": "Splunk",
+            "filename": "AristaAppForSplunk-"
+        },
+    },
     "EOS": {
         "64": {
             "extension": ".swi",

--- a/eos_downloader/object_downloader.py
+++ b/eos_downloader/object_downloader.py
@@ -461,9 +461,31 @@ class ObjectDownloader():
         if noztp:
             self._disable_ztp(file_path=file_path)
 
-
     def docker_import(self, version: str, image_name: str = "arista/ceos"):
         docker_image = f'{image_name}:{self.version}'
         logger.info(f'Importing image {self.filename} to {docker_image}')
         console.print(f'🚀 Importing image {self.filename} to {docker_image}')
         os.system(f'$(which docker) import {self.filename} {docker_image}')
+
+    def save_xml_folder(self, path_output: str = '.'):
+        """
+        save_xml_folder Download XML tree from Arista server
+
+        Parameters
+        ----------
+        path_output : str
+            Path to save XML data.
+
+        Returns
+        -------
+        ET.ElementTree
+            XML document
+        """
+        if self.session_id is None:
+            self.authenticate()
+        jsonpost = {'sessionCode': self.session_id}
+        result = requests.post(ARISTA_SOFTWARE_FOLDER_TREE, data=json.dumps(jsonpost))
+        folder_tree = (result.json()["data"]["xml"])
+        with open(path_output, 'w') as f:
+            f.writelines(folder_tree)
+        # return ET.ElementTree(ET.fromstring(folder_tree))

--- a/eos_downloader/swix.py
+++ b/eos_downloader/swix.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+import os
+import rich
+from loguru import logger
+from eos_downloader.object_downloader import ObjectDownloader
+from rich import console
+
+console = rich.get_console()
+
+
+class SWIXDownloader(ObjectDownloader):
+    """
+    SWIXDownloader Object to download SWIX packages from Arista.com website
+
+    Supercharge ObjectDownloader to support SWIX specific actions
+
+    Parameters
+    ----------
+    ObjectDownloader : ObjectDownloader
+        Base object
+    """
+    def _get_remote_filepath(self):
+        """
+        _get_remote_filepath Helper to get path of the file to download
+
+        Set XPATH and return result of _parse_xml for the file to download
+
+        Returns
+        -------
+        str
+            Remote path of the file to download
+        """
+        root = self._get_folder_tree()
+        logger.debug("GET XML content from ARISTA.com")
+        xpath = './/dir[@label="' + self.image + '"]//file'
+        return self._parse_xml(root_xml=root, xpath=xpath, search_file=self.filename)
+
+    def _get_remote_hashpath(self, hash_method: str = 'md5sum'):
+        """
+        _get_remote_hashpath Helper to get path of the hash's file to download
+
+        Set XPATH and return result of _parse_xml for the file to download
+
+        Returns
+        -------
+        str
+            Remote path of the hash's file to download
+        """
+        root = self._get_folder_tree()
+        logger.debug("GET XML content from ARISTA.com")
+        xpath = './/dir[@label="' + self.image + '"]//file'
+        return self._parse_xml(root_xml=root, xpath=xpath, search_file=self.filename + '.' + hash_method)


### PR DESCRIPTION
# Add support for TerminAttr download

## Status

Work In Progress

## Use case

- Add a CLI to download TerminAttr package like EOS images.
- Related to issue #12 

## Command line example:

```
$ python bin/swix-download --token <YOUR TOKEN> --package TerminAttr --version 1.20.0 --log --verbose debug
```

## Options

```
python bin/swix-download -h
usage: swix-download [-h] [--token TOKEN] [--package PACKAGE] --version VERSION [--destination DESTINATION] [--verbose VERBOSE] [--log]

EOS downloader script.

optional arguments:
  -h, --help            show this help message and exit
  --token TOKEN         arista.com user API key - can use ENV:ARISTA_TOKEN
  --package PACKAGE     EOS package
  --version VERSION     EOS version to download from website
  --destination DESTINATION
                        Path where to save EOS package downloaded
  --verbose VERBOSE     Script verbosity
  --log                 Option to activate logging to eos-downloader.log file
```