### PR TITLE
feat: Add better error handling for authentication

### DIFF
--- a/bin/eos-download
+++ b/bin/eos-download
@@ -48,6 +48,9 @@ if __name__ == '__main__':
     cli_options = read_cli()
 
     console = Console()
+    if cli_options.token is None or cli_options.token == '':
+        console.print('\n❗ Token is unset ! Please configure ARISTA_TOKEN or use --token option', style="bold red")
+        sys.exit(1)
 
     logger.remove()
     if cli_options.log:

--- a/eos_downloader/__init__.py
+++ b/eos_downloader/__init__.py
@@ -19,14 +19,15 @@ ARISTA_SOFTWARE_FOLDER_TREE = "https://www.arista.com/custom_data/api/cvp/getFol
 
 ARISTA_DOWNLOAD_URL = "https://www.arista.com/custom_data/api/cvp/getDownloadLink/"
 
-MSG_TOKEN_EXPIRED = """
-The API token has expired. Please visit arista.com, click on your profile and
+MSG_TOKEN_EXPIRED = """The API token has expired. Please visit arista.com, click on your profile and
 select Regenerate Token then re-run the script with the new token.
 """
 
-MSG_TOKEN_INVALID = """
-The API token is incorrect. Please visit arista.com, click on your profile and
+MSG_TOKEN_INVALID = """The API token is incorrect. Please visit arista.com, click on your profile and
 check the Access Token. Then re-run the script with the correct token.
+"""
+
+MSG_INVALID_DATA = """Invalid data returned by server
 """
 
 EVE_QEMU_FOLDER_PATH = '/opt/unetlab/addons/qemu/'


### PR DESCRIPTION
## Overview

Add better error handling for authentication mechanism

- Check if token is provided when script is starting
- Hide python stack trace when token is invalid and server returns invalid data

Fixing issue #14 

## Output examples

### Error when token is not provided

```bash
eos-download --image EOS --version 4.26.3M

❗ Token is unset ! Please configure ARISTA_TOKEN or use --token option
```

### Error when using invalid token:

```bash
eos-download --image EOS --version 4.26.3M
🪐 eos-downloader is starting...
    - Image Type: EOS
    - Version: 4.26.3M
❌  The API token has expired. Please visit arista.com, click on your profile and
select Regenerate Token then re-run the script with the new token.

❌  The API token has expired. Please visit arista.com, click on your profile and
select Regenerate Token then re-run the script with the new token.

❌  Invalid data returned by server
```