### PR TITLE
feat(eos_downloader.cli): Add support for EOS version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -345,3 +345,4 @@ report.html
 
 *.swp
 arista.xml
+tester.py

--- a/README.md
+++ b/README.md
@@ -63,6 +63,60 @@ Options:
                                   --image_type cEOSlab)
 ```
 
+You can use `--latest` and `--release-type` option to get latest EOS version matching a specific release type
+
+```bash
+# Get latest M release
+❯ ardl get eos --latest -rtype m
+🪐 eos-downloader is starting...
+    - Image Type: default
+    - Version: None
+🔎  Searching file EOS-4.29.3M.swi
+    -> Found file at /support/download/EOS-USA/Active Releases/4.29/EOS-4.29.3M/EOS-4.29.3M.swi
+...
+✅  Downloaded file is correct.
+✅  processing done !
+```
+
+### List available EOS versions from Arista website
+
+You can easily get list of available version using CLI as shown below:
+
+```bash
+❯ ardl info eos-versions
+Usage: ardl info eos-versions [OPTIONS]
+
+  List Available EOS version on Arista.com website.
+
+  Comes with some filters to get latest release (F or M) as well as branch
+  filtering
+
+    - To get latest M release available (without any branch): ardl info eos-
+    versions --latest -rtype m
+
+    - To get latest F release available: ardl info eos-versions --latest
+    -rtype F
+
+Options:
+  -b, --branch TEXT               EOS Branch to list releases
+  -rtype, -rtype, --release-type [F|M]
+                                  EOS release type to search
+  -l, --latest / --no-latest      Get latest version in given branch (require
+                                  --branch)
+  -v, --verbose / --no-verbose    Human readable output. Default is none to
+                                  use output in script)
+  --log-level, --log [debug|info|warning|error|critical]
+                                  Logging level of the command
+  --help                          Show this message and exit.
+```
+
+__Example__
+
+```bash
+❯ ardl info eos-versions -rtype m --branch 4.28
+['4.28.6.1M', '4.28.6M', '4.28.5.1M', '4.28.5M', '4.28.4M', '4.28.3M']
+```
+
 ### Download CVP package
 
 > Supported packages are: OVA, KVM, RPM, Upgrade

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Commands:
   version  Display version of ardl
 ```
 
+> **Warning**
+> To use this CLI you need to get a valid token from your [Arista Account page](https://www.arista.com/en/users/profile).
+> For technical reason, it is only available for customers with active maintenance contracts and not for personnal accounts
+
 ### Download EOS Package
 
 
@@ -44,23 +48,31 @@ $ ardl get eos --version 4.28.3M --image-type cEOS
 Available options are :
 
 ```bash
+Usage: ardl get eos [OPTIONS]
+
+  Download EOS image from Arista website
+
 Options:
   --image-type [64|INT|2GB-INT|cEOS|cEOS64|vEOS|vEOS-lab|EOS-2GB|default]
                                   EOS Image type  [required]
-  --version TEXT                  EOS version  [required]
+  --version TEXT                  EOS version
+  -l, --latest                    Get latest version in given branch. If
+                                  --branch is not use, get the latest branch
+                                  with specific release type
+  -rtype, --release-type [F|M]    EOS release type to search
+  -b, --branch TEXT               EOS Branch to list releases
   --docker-name TEXT              Docker image name (default: arista/ceos)
                                   [default: arista/ceos]
   --output PATH                   Path to save image  [default: .]
   --log-level, --log [debug|info|warning|error|critical]
                                   Logging level of the command
-  --eve-ng / --no-eve-ng          Run EVE-NG vEOS provisioning (only if CLI
+  --eve-ng                        Run EVE-NG vEOS provisioning (only if CLI
                                   runs on an EVE-NG server)
-  --disable-ztp / --no-disable-ztp
-                                  Disable ZTP process in vEOS image (only
+  --disable-ztp                   Disable ZTP process in vEOS image (only
                                   available with --eve-ng)
-  --import-docker / --no-import-docker
-                                  Import docker image (only available with
+  --import-docker                 Import docker image (only available with
                                   --image_type cEOSlab)
+  --help                          Show this message and exit.
 ```
 
 You can use `--latest` and `--release-type` option to get latest EOS version matching a specific release type
@@ -98,12 +110,12 @@ Usage: ardl info eos-versions [OPTIONS]
     -rtype F
 
 Options:
+  -l, --latest                    Get latest version in given branch. If
+                                  --branch is not use, get the latest branch
+                                  with specific release type
+  -rtype, --release-type [F|M]    EOS release type to search
   -b, --branch TEXT               EOS Branch to list releases
-  -rtype, -rtype, --release-type [F|M]
-                                  EOS release type to search
-  -l, --latest / --no-latest      Get latest version in given branch (require
-                                  --branch)
-  -v, --verbose / --no-verbose    Human readable output. Default is none to
+  -v, --verbose                   Human readable output. Default is none to
                                   use output in script)
   --log-level, --log [debug|info|warning|error|critical]
                                   Logging level of the command

--- a/eos_downloader/__init__.py
+++ b/eos_downloader/__init__.py
@@ -10,11 +10,12 @@ from __future__ import (absolute_import, division,
 import dataclasses
 from typing import Any
 import json
+import importlib.metadata
 
 __author__ = '@titom73'
 __email__ = 'tom@inetsix.net'
 __date__ = '2022-03-16'
-__version__ = '0.7.1'
+__version__ = importlib.metadata.version("eos-downloader")
 
 # __all__ = ["CvpAuthenticationItem", "CvFeatureManager", "EOSDownloader", "ObjectDownloader", "reverse"]
 

--- a/eos_downloader/cli/cli.py
+++ b/eos_downloader/cli/cli.py
@@ -15,6 +15,7 @@ from rich.console import Console
 import eos_downloader
 from eos_downloader.cli.get import commands as get_commands
 from eos_downloader.cli.debug import commands as debug_commands
+from eos_downloader.cli.info import commands as info_commands
 
 
 @click.group()
@@ -42,6 +43,12 @@ def get(ctx: click.Context) -> None:
 
 @ardl.group(no_args_is_help=True)
 @click.pass_context
+def info(ctx: click.Context) -> None:
+    # pylint: disable=redefined-builtin
+    """List information from Arista website"""
+
+@ardl.group(no_args_is_help=True)
+@click.pass_context
 def debug(ctx: click.Context) -> None:
     # pylint: disable=redefined-builtin
     """Debug commands to work with ardl"""
@@ -54,7 +61,9 @@ def cli() -> None:
     # Load group commands
     get.add_command(get_commands.eos)
     get.add_command(get_commands.cvp)
+    info.add_command(info_commands.eos_versions)
     debug.add_command(debug_commands.xml)
+    debug.add_command(debug_commands.list_eos_versions)
     ardl.add_command(version)
     # Load CLI
     ardl(

--- a/eos_downloader/cli/cli.py
+++ b/eos_downloader/cli/cli.py
@@ -63,7 +63,6 @@ def cli() -> None:
     get.add_command(get_commands.cvp)
     info.add_command(info_commands.eos_versions)
     debug.add_command(debug_commands.xml)
-    debug.add_command(debug_commands.list_eos_versions)
     ardl.add_command(version)
     # Load CLI
     ardl(

--- a/eos_downloader/cli/debug/commands.py
+++ b/eos_downloader/cli/debug/commands.py
@@ -50,3 +50,35 @@ def xml(ctx: click.Context, output: str, log_level: str) -> None:
         f.write(str(xmlstr))
 
     console.print(f'XML file saved in: { output }')
+
+
+@click.command()
+@click.pass_context
+@click.option('--log-level', '--log', help='Logging level of the command', default='debug', type=click.Choice(['debug', 'info', 'warning', 'error', 'critical'], case_sensitive=False))
+def list_eos_versions(ctx: click.Context, log_level: str) -> None:
+    """Extract XML directory structure"""
+    console = Console()
+    # Get from Context
+    token = ctx.obj['token']
+
+    logger.remove()
+    if log_level is not None:
+        logger.add("eos-downloader.log", rotation="10 MB", level=log_level.upper())
+
+    my_download = eos_downloader.eos.EOSDownloader(
+        image='unset',
+        software='EOS',
+        version='unset',
+        token=token,
+        hash_method='sha512sum')
+
+    my_download.authenticate()
+    # my_download.debug_version()
+    branches = my_download.latest_branch()
+    console.print(branches)
+    # console.print(f'--> Branch: {branches[0]}')
+    # console.print(my_download.get_versions(str(branches[0])))
+
+    # console.print(
+    #     my_download.debug_version()
+    # )

--- a/eos_downloader/cli/debug/commands.py
+++ b/eos_downloader/cli/debug/commands.py
@@ -50,35 +50,3 @@ def xml(ctx: click.Context, output: str, log_level: str) -> None:
         f.write(str(xmlstr))
 
     console.print(f'XML file saved in: { output }')
-
-
-@click.command()
-@click.pass_context
-@click.option('--log-level', '--log', help='Logging level of the command', default='debug', type=click.Choice(['debug', 'info', 'warning', 'error', 'critical'], case_sensitive=False))
-def list_eos_versions(ctx: click.Context, log_level: str) -> None:
-    """Extract XML directory structure"""
-    console = Console()
-    # Get from Context
-    token = ctx.obj['token']
-
-    logger.remove()
-    if log_level is not None:
-        logger.add("eos-downloader.log", rotation="10 MB", level=log_level.upper())
-
-    my_download = eos_downloader.eos.EOSDownloader(
-        image='unset',
-        software='EOS',
-        version='unset',
-        token=token,
-        hash_method='sha512sum')
-
-    my_download.authenticate()
-    # my_download.debug_version()
-    branches = my_download.latest_branch()
-    console.print(branches)
-    # console.print(f'--> Branch: {branches[0]}')
-    # console.print(my_download.get_versions(str(branches[0])))
-
-    # console.print(
-    #     my_download.debug_version()
-    # )

--- a/eos_downloader/cli/get/commands.py
+++ b/eos_downloader/cli/get/commands.py
@@ -27,18 +27,17 @@ CVP_IMAGE_TYPE = ['ova', 'rpm', 'kvm', 'upgrade']
 @click.pass_context
 @click.option('--image-type', default='default', help='EOS Image type', type=click.Choice(EOS_IMAGE_TYPE), required=True)
 @click.option('--version', default=None, help='EOS version', type=str, required=False)
-@click.option('--latest/--no-latest', '-l', type=click.BOOL, default=False, help='Get latest version in given branch (require --branch)')
-@click.option('--release-type', '-rtype', '-rtype', type=click.Choice(RTYPES, case_sensitive=False), default=RTYPE_FEATURE, help='EOS release type to search')
+@click.option('--latest', '-l', is_flag=True, type=click.BOOL, default=False, help='Get latest version in given branch. If --branch is not use, get the latest branch with specific release type')
+@click.option('--release-type', '-rtype', type=click.Choice(RTYPES, case_sensitive=False), default=RTYPE_FEATURE, help='EOS release type to search')
 @click.option('--branch', '-b', type=click.STRING, default=None, help='EOS Branch to list releases')
-
 @click.option('--docker-name', default='arista/ceos', help='Docker image name (default: arista/ceos)', type=str, show_default=True)
 @click.option('--output', default=str(os.path.relpath(os.getcwd(), start=os.curdir)), help='Path to save image', type=click.Path(),show_default=True)
 # Debugging
 @click.option('--log-level', '--log', help='Logging level of the command', default=None, type=click.Choice(['debug', 'info', 'warning', 'error', 'critical'], case_sensitive=False))
 # Boolean triggers
-@click.option('--eve-ng/--no-eve-ng', help='Run EVE-NG vEOS provisioning (only if CLI runs on an EVE-NG server)', default=False)
-@click.option('--disable-ztp/--no-disable-ztp', help='Disable ZTP process in vEOS image (only available with --eve-ng)', default=False)
-@click.option('--import-docker/--no-import-docker', help='Import docker image (only available with --image_type cEOSlab)', default=False)
+@click.option('--eve-ng', is_flag=True, help='Run EVE-NG vEOS provisioning (only if CLI runs on an EVE-NG server)', default=False)
+@click.option('--disable-ztp', is_flag=True, help='Disable ZTP process in vEOS image (only available with --eve-ng)', default=False)
+@click.option('--import-docker', is_flag=True, help='Import docker image (only available with --image_type cEOSlab)', default=False)
 def eos(
     ctx: click.Context, image_type: str, output: str, log_level: str, eve_ng: bool, disable_ztp: bool,
     import_docker: bool, docker_name: str, version: str = None, release_type: str = None,
@@ -85,8 +84,6 @@ def eos(
             console.print(f'[red]Error[/red], cannot find any version in {branch} for {release_type} release type')
             sys.exit(1)
         my_download.version = str(latest_version)
-
-
 
     if eve_ng:
         my_download.provision_eve(noztp=disable_ztp, checksum=True)

--- a/eos_downloader/cli/info/commands.py
+++ b/eos_downloader/cli/info/commands.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# coding: utf-8 -*-
+# pylint: disable=no-value-for-parameter
+# pylint: disable=too-many-arguments
+# pylint: disable=line-too-long
+# pylint: disable=redefined-builtin
+# flake8: noqa E501
+
+"""
+Commands for ARDL CLI to list data.
+"""
+
+import os
+import sys
+
+import click
+from loguru import logger
+from rich.console import Console
+
+import eos_downloader.eos
+from eos_downloader.models.version import BASE_VERSION_STR, BASE_BRANCH_STR
+
+
+@click.command()
+@click.pass_context
+@click.option('--branch', '-b', type=click.STRING, default=None, help='EOS Branch to list releases')
+@click.option('--release-type', '-r', type=click.Choice(['m', 'f'], case_sensitive=False), default=None, help='EOS release type to search')
+@click.option('--latest/--no-latest', '-l', type=click.BOOL, default=False, help='Get latest version in given branch (require --branch)')
+@click.option('--verbose/--no-verbose', '-v', type=click.BOOL, default=False, help='Human readable output. Default is none to use output in script)')
+@click.option('--log-level', '--log', help='Logging level of the command', default='warning', type=click.Choice(['debug', 'info', 'warning', 'error', 'critical'], case_sensitive=False))
+def eos_versions(ctx: click.Context, log_level: str, branch: str = None, release_type: str = None, latest: bool = False, verbose: bool = False) -> None:
+    """
+    List Available EOS version on Arista.com website.
+
+    Comes with some filters to get latest release (F or M) as well as branch filtering
+    """
+    console = Console()
+    # Get from Context
+    token = ctx.obj['token']
+
+    logger.remove()
+    if log_level is not None:
+        logger.add("eos-downloader.log", rotation="10 MB", level=log_level.upper())
+
+    my_download = eos_downloader.eos.EOSDownloader(
+        image='unset',
+        software='EOS',
+        version='unset',
+        token=token,
+        hash_method='sha512sum')
+
+    auth = my_download.authenticate()
+    if verbose and auth:
+        console.print('✅ Authenticated on arista.com')
+
+    if release_type is not None:
+        release_type = release_type.upper()
+
+    if branch is None:
+        branch = str(my_download.latest_branch().branch())
+
+    if latest:
+        latest_version = my_download.latest_eos(branch,release_type)
+        if str(latest_version) == BASE_VERSION_STR:
+            latest_version = f'version not found in branch {branch}'
+        if verbose:
+            if branch is not None:
+                console.print(f'Latest release for {branch}: {latest_version}')
+            else:
+                console.print(f'Latest EOS release: {latest_version}')
+        else:
+            console.print(f'{ latest_version }')
+    else:
+        versions = my_download.get_eos_versions(branch=branch)
+        if verbose:
+            console.print(f'List of available versions for {branch}')
+            for version in versions:
+                console.print(f'  → {str(version)}')
+        else:
+            console.print(f'{[str(version) for version in versions]}')

--- a/eos_downloader/cli/info/commands.py
+++ b/eos_downloader/cli/info/commands.py
@@ -25,10 +25,10 @@ from eos_downloader.models.version import BASE_VERSION_STR, RTYPES, RTYPE_FEATUR
 
 @click.command(no_args_is_help=True)
 @click.pass_context
+@click.option('--latest', '-l', is_flag=True, type=click.BOOL, default=False, help='Get latest version in given branch. If --branch is not use, get the latest branch with specific release type')
+@click.option('--release-type', '-rtype', type=click.Choice(RTYPES, case_sensitive=False), default=RTYPE_FEATURE, help='EOS release type to search')
 @click.option('--branch', '-b', type=click.STRING, default=None, help='EOS Branch to list releases')
-@click.option('--release-type', '-rtype', '-rtype', type=click.Choice(RTYPES, case_sensitive=False), default=RTYPE_FEATURE, help='EOS release type to search')
-@click.option('--latest/--no-latest', '-l', type=click.BOOL, default=False, help='Get latest version in given branch (require --branch)')
-@click.option('--verbose/--no-verbose', '-v', type=click.BOOL, default=False, help='Human readable output. Default is none to use output in script)')
+@click.option('--verbose', '-v', is_flag=True, type=click.BOOL, default=False, help='Human readable output. Default is none to use output in script)')
 @click.option('--log-level', '--log', help='Logging level of the command', default='warning', type=click.Choice(['debug', 'info', 'warning', 'error', 'critical'], case_sensitive=False))
 def eos_versions(ctx: click.Context, log_level: str, branch: str = None, release_type: str = None, latest: bool = False, verbose: bool = False) -> None:
     """
@@ -67,7 +67,8 @@ def eos_versions(ctx: click.Context, log_level: str, branch: str = None, release
             branch = str(my_download.latest_branch(rtype=release_type).branch)
         latest_version = my_download.latest_eos(branch, rtype=release_type)
         if str(latest_version) == BASE_VERSION_STR:
-            latest_version = f'version not found in branch {branch}'
+            console.print(f'[red]Error[/red], cannot find any version in {branch} for {release_type} release type')
+            sys.exit(1)
         if verbose:
             console.print(f'Branch {branch} has been selected with release type {release_type}')
             if branch is not None:

--- a/eos_downloader/eos.py
+++ b/eos_downloader/eos.py
@@ -11,8 +11,11 @@ import os
 import rich
 from loguru import logger
 from rich import console
+import xml.etree.ElementTree as ET
+from typing import List
 
 from eos_downloader.object_downloader import ObjectDownloader
+from eos_downloader.models.version import eos_version_reg, EosVersion, BASE_VERSION_STR, BASE_BRANCH_STR
 
 console = rich.get_console()
 
@@ -55,3 +58,51 @@ class EOSDownloader(ObjectDownloader):
         os.system(f"guestunmount {os.path.join(file_path, 'raw')}")
         os.system(f"rm -rf {os.path.join(file_path, 'raw')}")
         logger.info(f"Volume has been successfully unmounted at {file_path}")
+
+    def _parse_xml_for_version(self,root_xml: ET.ElementTree, xpath: str = './/dir[@label="Active Releases"]/dir/dir/[@label]') -> List[str]:
+        # XPATH: .//dir[@label="Active Releases"]/dir/dir/[@label]
+        logger.debug(f'Using xpath {xpath}')
+        eos_versions = []
+        for node in root_xml.findall(xpath):
+            if 'label' in node.attrib and eos_version_reg.match(node.get('label')):
+                eos_version = EosVersion.from_str(node.get("label"))
+                eos_versions.append(eos_version)
+                logger.debug(f"Found {node.get('label')} - {eos_version}")
+        return eos_versions
+
+    def _get_branches(self):
+        root = self._get_folder_tree()
+        versions = self._parse_xml_for_version(root_xml=root)
+        return list(set(version.branch() for version in versions))
+
+    def latest_branch(self):
+        selected_branch = EosVersion.from_str(BASE_BRANCH_STR)
+        for branch in self._get_branches():
+            branch = EosVersion.from_str(branch)
+            if branch > selected_branch:
+                selected_branch = branch
+        return selected_branch
+
+    def get_eos_versions(self, branch: str = None):
+        root = self._get_folder_tree()
+        result = []
+        for version in self._parse_xml_for_version(root_xml=root):
+            if branch is None:
+                result.append(version)
+            elif version.is_in_branch(branch):
+                result.append(version)
+        return result
+
+    def latest_eos(self, branch: str = None, rtype: str = None):
+        selected_version = EosVersion.from_str(BASE_VERSION_STR)
+        if branch is None:
+            latest_branch = self.latest_branch()
+        else:
+            latest_branch = EosVersion.from_str(branch)
+        for version in self.get_eos_versions(branch=str(latest_branch.branch())):
+            if version > selected_version:
+                if rtype is not None and version.rtype == rtype:
+                    selected_version = version
+                if rtype is None:
+                    selected_version = version
+        return selected_version

--- a/eos_downloader/models/version.py
+++ b/eos_downloader/models/version.py
@@ -1,0 +1,211 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+import re
+import logging
+from typing import Any, Dict, Iterator, List, Optional, Type, Union
+from pydantic import BaseModel, validator
+
+
+# Regular Expression to capture multiple EOS version format
+# 4.24
+# 4.23.0
+# 4.21.1M
+# 4.28.10.F
+# 4.28.6.1M
+eos_version_reg = re.compile(r"^.*(?P<major>4)\.*(?P<minor>\d{2})*\.*(?P<patch>\d{1,2})\.*(\d{1,2}){0,1}\.*\d*(?P<rtype>[M,F])*$")
+
+
+class EosVersion(BaseModel):
+    """
+    EosVersion object to play with version management in code
+
+    Since EOS is not using strictly semver approach, this class mimic some functions from semver lib for Arista EOS versions
+    It is based on Pydantic and provides helpers for comparison:
+
+    Examples:
+    >>> eos_version_str = '4.23.2F'
+    >>> eos_version = EosVersion.from_str(eos_version_str)
+    >>> print(f'str representation is: {str(eos_version)}')
+    str representation is: 4.23.2F
+
+    >>> other_version = EosVersion.from_str(other_version_str)
+    >>> print(f'eos_version < other_version: {eos_version < other_version}')
+    eos_version < other_version: True
+
+    >>> print(f'Is eos_version match("<=4.23.3M"): {eos_version.match("<=4.23.3M")}')
+    Is eos_version match("<=4.23.3M"): True
+
+    >>> print(f'Is eos_version in branch 4.23: {eos_version.is_in_branch("4.23.0")}')
+    Is eos_version in branch 4.23: True
+
+    Args:
+        BaseModel (Pydantic): Pydantic Base Model
+    """
+    major: Optional[int] = 0
+    minor: Optional[int] = 0
+    patch: Optional[int] = 0
+    rtype: Optional[str]
+
+    @classmethod
+    def from_str(cls, eos_version: str):
+        """
+        Class constructor from a string representing EOS version
+
+        Use regular expresion to extract fields from string.
+        It supports following formats:
+        - 4.24
+        - 4.23.0
+        - 4.21.1M
+        - 4.28.10.F
+        - 4.28.6.1M
+
+        Args:
+            eos_version (str): EOS version in str format
+
+        Returns:
+            EosVersion object
+        """
+        logging.debug(f'receiving version: {eos_version}')
+        if eos_version_reg.match(eos_version):
+            matches = eos_version_reg.match(eos_version)
+            return cls(**matches.groupdict())
+        else:
+            logging.error(f'Error occured with {eos_version}')
+
+    def __str__(self) -> str:
+        """
+        Standard str representation
+
+        Return string for EOS version like 4.23.3M
+
+        Returns:
+            str: A standard EOS version string representing <MAJOR>.<MINOR>.<PATCH><RTYPE>
+        """
+        return f'{self.major}.{self.minor}.{self.patch}{self.rtype}'
+
+    def _compare(self, other) -> float:
+        """
+        An internal comparison function to compare 2 EosVersion objects
+
+        Do a deep comparison from Major to Release Type
+        The return value is
+        - negative if ver1 < ver2,
+        - zero if ver1 == ver2
+        - strictly positive if ver1 > ver2
+
+        Args:
+            other (EosVersion): An EosVersion to compare with this object
+
+        Raises:
+            ValueError: Raise ValueError if input is incorrect type
+
+        Returns:
+            float: -1 if ver1 < ver2, 0 if ver1 == ver2, 1 if ver1 > ver2
+        """
+        if not isinstance(other, EosVersion):
+            raise ValueError(f'could not compare {other} as it is not an EosVersion object')
+        logging.debug(f'comparing {self.dict()} with {other.dict()}')
+        comparison_flag: float = 0
+        for key,value in self.dict().items():
+            if comparison_flag == 0 and self.dict()[key] < other.dict()[key]:
+                comparison_flag = -1
+            if comparison_flag == 0 and self.dict()[key] > other.dict()[key]:
+                comparison_flag = 1
+            if comparison_flag != 0:
+                return comparison_flag
+        return comparison_flag
+
+    def __eq__(self, other):
+        """ Implement __eq__ function (==) """
+        return self._compare(other) == 0
+
+    def __ne__(self, other):
+        """ Implement __nw__ function (!=) """
+        return self._compare(other) != 0
+
+    def __lt__(self, other):
+        """ Implement __lt__ function (<) """
+        return self._compare(other) < 0
+
+    def __le__(self, other):
+        """ Implement __le__ function (<=) """
+        return self._compare(other) <= 0
+
+    def __gt__(self, other):
+        """ Implement __gt__ function (>) """
+        return self._compare(other) > 0
+
+    def __ge__(self, other):
+        """ Implement __ge__ function (>=) """
+        return self._compare(other) >= 0
+
+    def match(self, match_expr: str) -> bool:
+        """
+        Compare self to match a match expression.
+
+        Example:
+        >>> eos_version.match("<=4.23.3M")
+        True
+        >>> eos_version.match("==4.23.3M")
+        False
+
+        Args:
+            match_expr (str):  optional operator and version; valid operators are
+              ``<``   smaller than
+              ``>``   greater than
+              ``>=``  greator or equal than
+              ``<=``  smaller or equal than
+              ``==``  equal
+              ``!=``  not equal
+
+        Raises:
+            ValueError: If input has no match_expr nor match_ver
+
+        Returns:
+            bool: True if the expression matches the version, otherwise False
+        """
+        prefix = match_expr[:2]
+        if prefix in (">=", "<=", "==", "!="):
+            match_version = match_expr[2:]
+        elif prefix and prefix[0] in (">", "<"):
+            prefix = prefix[0]
+            match_version = match_expr[1:]
+        elif match_expr and match_expr[0] in "0123456789":
+            prefix = "=="
+            match_version = match_expr
+        else:
+            raise ValueError(
+                "match_expr parameter should be in format <op><ver>, "
+                "where <op> is one of "
+                "['<', '>', '==', '<=', '>=', '!=']. "
+                "You provided: %r" % match_expr
+            )
+        logging.debug(f'work on comparison {prefix} with base release {match_version}')
+        possibilities_dict = {
+            ">": (1,),
+            "<": (-1,),
+            "==": (0,),
+            "!=": (-1, 1),
+            ">=": (0, 1),
+            "<=": (-1, 0),
+        }
+        possibilities = possibilities_dict[prefix]
+        cmp_res = self._compare(EosVersion.from_str(match_version))
+
+        return cmp_res in possibilities
+
+    def is_in_branch(self, branch_str: str) -> bool:
+        """
+        Check if current version is part of a branch version
+
+        Comparison is done across MAJOR and MINOR
+
+        Args:
+            branch_str (str): a string for EOS branch. It supports following formats 4.23 or 4.23.0
+
+        Returns:
+            bool: True if current version is in provided branch, otherwise False
+        """
+        branch = EosVersion.from_str(branch_str)
+        return self.major == branch.major and self.minor == branch.minor

--- a/eos_downloader/models/version.py
+++ b/eos_downloader/models/version.py
@@ -221,4 +221,10 @@ class EosVersion(BaseModel):
         return self.major == branch.major and self.minor == branch.minor
 
     def branch(self) -> str:
+        """
+        Extract branch of version
+
+        Returns:
+            str: branch from version
+        """
         return f'{self.major}.{self.minor}'

--- a/eos_downloader/object_downloader.py
+++ b/eos_downloader/object_downloader.py
@@ -86,7 +86,7 @@ class ObjectDownloader():
         self.filename = self._build_filename()
 
     # ------------------------------------------------------------------------ #
-    # Private METHODS
+    # Internal METHODS
     # ------------------------------------------------------------------------ #
 
     def _build_filename(self) -> str:
@@ -104,7 +104,7 @@ class ObjectDownloader():
             return f"{DATA_MAPPING[self.software]['default']['prepend']}-{self.version}{DATA_MAPPING[self.software]['default']['extension']}"
         return ''
 
-    def _parse_xml(self, root_xml: ET.ElementTree, xpath: str, search_file: str) -> str:
+    def _parse_xml_for_path(self, root_xml: ET.ElementTree, xpath: str, search_file: str) -> str:
         # sourcery skip: remove-unnecessary-cast
         """
         _parse_xml Read and extract data from XML using XPATH
@@ -259,7 +259,7 @@ class ObjectDownloader():
         root = self._get_folder_tree()
         logger.debug("GET XML content from ARISTA.com")
         xpath = f'.//dir[@label="{self.software}"]//file'
-        return self._parse_xml(root_xml=root, xpath=xpath, search_file=self.filename)
+        return self._parse_xml_for_path(root_xml=root, xpath=xpath, search_file=self.filename)
 
     def _get_remote_hashpath(self, hash_method: str = 'md5sum') -> str:
         """
@@ -275,7 +275,7 @@ class ObjectDownloader():
         root = self._get_folder_tree()
         logger.debug("GET XML content from ARISTA.com")
         xpath = f'.//dir[@label="{self.software}"]//file'
-        return self._parse_xml(
+        return self._parse_xml_for_path(
             root_xml=root,
             xpath=xpath,
             search_file=f'{self.filename}.{hash_method}',
@@ -389,7 +389,6 @@ class ObjectDownloader():
             if 'data' in result.json():
                 self.session_id = result.json()["data"]["session_code"]
                 logger.info('Authenticated on arista.com')
-                console.print('✅ Authenticated on arista.com')
                 return True
             logger.debug(f'{result.json()}')
             return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 "cvprac>=1.0.7",
 "click==8.1.3",
 "click-help-colors==0.9.1",
+"pydantic==1.10.4",
 ]
 keywords = ["eos_downloader", "Arista", "eos", "cvp", "network", "automation", "networking", "devops", "netdevops"]
 classifiers = [
@@ -116,7 +117,7 @@ warn_untyped_fields = true
 legacy_tox_ini = """
 [tox]
 min_version = 4.0
-envlist = 
+envlist =
   clean,
   lint,
   type
@@ -124,7 +125,7 @@ envlist =
 
 [tox-full]
 min_version = 4.0
-envlist = 
+envlist =
   clean,
   py{38,39,310},
   lint,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eos_downloader"
-version = "v0.7.1"
+version = "v0.8.0-dev1"
 readme = "README.md"
 authors = [{ name = "Thomas Grimonet", email = "thomas.grimonet@gmail.com" }]
 maintainers = [


### PR DESCRIPTION
PR based on issue #27 and new features.

## Todo List

- [x] Being able to filter versions
- [x] Being able to get latest M or F version even if M is not available in latest branch
- [x] Implement filter in `ardl get` commands
- [x] Website documentation for new commands and options
- [ ] Implement testing

## Testing

```
pip install git+https://github.com/titom73/eos-downloader.git@feat/issue27
```

## Get EOS version information

Retrieve information from arista.com to get EOS versions.

> **Note**
> Download is not supported in these CLI commands

```bash
❯ ardl info eos-versions --help
Usage: ardl info eos-versions [OPTIONS]

  List Available EOS version on Arista.com website.

  Comes with some filters to get latest release (F or M) as well as branch
  filtering

Options:
  -b, --branch TEXT               EOS Branch to list releases
  -r, --release-type [m|f]        EOS release type to search
  -l, --latest / --no-latest      Get latest version in given branch (require
                                  --branch)
  -v, --verbose / --no-verbose    Human readable output. Default is none to
                                  use output in script)
  --log-level, --log [debug|info|warning|error|critical]
                                  Logging level of the command
  --help                          Show this message and exit.
```

- Get list of all versions in a specific branch for a specific release type

```bash
❯ ardl info eos-versions -rtype m --branch 4.28
['4.28.6.1M', '4.28.6M', '4.28.5.1M', '4.28.5M', '4.28.4M', '4.28.3M']
```

- Get latest M release in a given branch

```bash
❯ ardl info eos-versions --latest -r m -b 4.29
4.29.3M
```

- Get lastest release available (from semver standpoint)

```bash
❯ ardl info eos-versions -rtype F --latest
4.30.0F

❯ ardl info eos-versions -rtype m --latest
4.29.3M
```

## Use latest, branch and rtype in downloads

```bash
# Get lastest F version
❯ ardl get eos --latest
🪐 eos-downloader is starting...
    - Image Type: default
    - Version: None
🔎  Searching file EOS-4.30.0F.swi
    -> Found file at /support/download/EOS-USA/Active Releases/4.30/EOS-4.30.0F/EOS-4.30.0F.swi
...
✅  Downloaded file is correct.
✅  processing done !

# Get latest M release
❯ ardl get eos --latest -rtype m
🪐 eos-downloader is starting...
    - Image Type: default
    - Version: None
🔎  Searching file EOS-4.29.3M.swi
    -> Found file at /support/download/EOS-USA/Active Releases/4.29/EOS-4.29.3M/EOS-4.29.3M.swi
...
✅  Downloaded file is correct.
✅  processing done !

# Get latest M release in branch 4.23
❯ ardl get eos --latest -rtype m --branch 4.23
🪐 eos-downloader is starting...
    - Image Type: default
    - Version: None
🔎  Searching file EOS-4.23.13M.swi
    -> Found file at /support/download/EOS-USA/Active Releases/4.23/EOS-4.23.13M/EOS-4.23.13M.swi
...
✅  Downloaded file is correct.
✅  processing done !
```