### PR TITLE
fix(eos_download.models.version): Support rtype to be optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
             ${{ secrets.DOCKER_IMAGE }}
             ghcr.io/${{ secrets.DOCKER_IMAGE }}
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{raw}}
             type=raw,value=latest
 
       - name: Login to DockerHub
@@ -97,7 +97,7 @@ jobs:
   docker_in_docker:
     name: Docker Image Build with Docker support
     runs-on: ubuntu-latest
-    needs: [pypi]
+    needs: [docker]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -110,7 +110,7 @@ jobs:
             ${{ secrets.DOCKER_IMAGE }}
             ghcr.io/${{ secrets.DOCKER_IMAGE }}
           tags: |
-            type=semver,pattern={{version}}-dind
+            type=semver,pattern={{raw}}-dind
             type=raw,value=latest-dind
 
       - name: Login to DockerHub

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY . /local
 
 LABEL maintainer="Thomas Grimonet <tom@inetsix.net>"
 LABEL   "org.opencontainers.image.title"="eos-downloader" \
+        "org.opencontainers.image.description"="eos-downloader container" \
         "org.opencontainers.artifact.description"="A CLI to manage Arista EOS version download" \
         "org.opencontainers.image.source"="https://github.com/titom73/eos-downloader" \
         "org.opencontainers.image.url"="https://github.com/titom73/eos-downloader" \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- [![code-testing](https://github.com/titom73/eos-downloader/actions/workflows/pr-management.yml/badge.svg?event=push)](https://github.com/titom73/eos-downloader/actions/workflows/pr-management.yml) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/eos-downloader) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/titom73/arista-downloader) ![PyPI - Downloads](https://img.shields.io/pypi/dm/eos-downloader) ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/titom73/eos-downloader/edge)
+ [![code-testing](https://github.com/titom73/eos-downloader/actions/workflows/pr-management.yml/badge.svg?event=push)](https://github.com/titom73/eos-downloader/actions/workflows/pr-management.yml) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/eos-downloader) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/titom73/arista-downloader) ![PyPI - Downloads/month](https://img.shields.io/pypi/dm/eos-downloader) ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/titom73/eos-downloader/edge)
 
 # Arista Software Downloader
 

--- a/eos_downloader/__init__.py
+++ b/eos_downloader/__init__.py
@@ -6,7 +6,7 @@ EOS Downloader module.
 """
 
 from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
+                        print_function, unicode_literals, annotations)
 import dataclasses
 from typing import Any
 import json

--- a/eos_downloader/cvp.py
+++ b/eos_downloader/cvp.py
@@ -6,12 +6,16 @@ CVP Uploader content
 """
 
 import os
+import logging
 from typing import List, Optional, Any
 from dataclasses import dataclass
 from loguru import logger
 from cvprac.cvp_client import CvpClient
 from cvprac.cvp_client_errors import CvpLoginError
 
+from eos_downloader.tools import exc_to_str
+
+logger = logging.getLogger(__name__)
 
 @dataclass
 class CvpAuthenticationItem:

--- a/eos_downloader/eos.py
+++ b/eos_downloader/eos.py
@@ -7,6 +7,7 @@ Specific EOS inheritance from object_download
 """
 
 import os
+import logging
 import xml.etree.ElementTree as ET
 from typing import List, Union
 
@@ -16,6 +17,8 @@ from rich import console
 
 from eos_downloader.models.version import BASE_BRANCH_STR, BASE_VERSION_STR, REGEX_EOS_VERSION, RTYPE_FEATURE, EosVersion
 from eos_downloader.object_downloader import ObjectDownloader
+
+logger = logging.getLogger(__name__)
 
 console = rich.get_console()
 

--- a/eos_downloader/object_downloader.py
+++ b/eos_downloader/object_downloader.py
@@ -9,7 +9,7 @@ eos_downloader class definition
 """
 
 from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+                        unicode_literals, annotations)
 
 import base64
 import glob
@@ -17,6 +17,7 @@ import hashlib
 import json
 import os
 # from builtins import *
+import logging
 import sys
 import xml.etree.ElementTree as ET
 from typing import Union
@@ -32,6 +33,8 @@ from eos_downloader import (ARISTA_DOWNLOAD_URL, ARISTA_GET_SESSION,
                             MSG_INVALID_DATA, MSG_TOKEN_EXPIRED)
 from eos_downloader.data import DATA_MAPPING
 from eos_downloader.download import DownloadProgressBar
+
+logger = logging.getLogger(__name__)
 
 console = rich.get_console()
 

--- a/eos_downloader/tools.py
+++ b/eos_downloader/tools.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+"""Module for tools related to ardl"""
+
+def exc_to_str(exception: Exception) -> str:
+    """
+    Helper function to parse Exceptions
+    """
+    return (
+        f"{type(exception).__name__}{f' ({str(exception)})' if str(exception) else ''}"
+    )


### PR DESCRIPTION
Fix issue #30

Make EosVersion.rtype optional to allow branch management.

- fix(eos_downloader): Enable rtype to be optional
- fix(eos_download): configure logger in entire module
