### PR TITLE
feat(cli): Add support for CLI shortcut

### DIFF
--- a/eos_downloader/cli/cli.py
+++ b/eos_downloader/cli/cli.py
@@ -17,8 +17,10 @@ from eos_downloader.cli.get import commands as get_commands
 from eos_downloader.cli.debug import commands as debug_commands
 from eos_downloader.cli.info import commands as info_commands
 
+from eos_downloader.cli.utils import AliasedGroup
 
-@click.group()
+
+@click.group(cls=AliasedGroup)
 @click.pass_context
 @click.option('--token', show_envvar=True, default=None, help='Arista Token from your customer account')
 def ardl(ctx: click.Context, token: str) -> None:
@@ -34,23 +36,23 @@ def version() -> None:
     console.print(f'ardl is running version {eos_downloader.__version__}')
 
 
-@ardl.group(no_args_is_help=True)
+@ardl.group(cls=AliasedGroup, no_args_is_help=True)
 @click.pass_context
-def get(ctx: click.Context) -> None:
+def get(ctx: click.Context, cls: click.Group = AliasedGroup) -> None:
     # pylint: disable=redefined-builtin
     """Download Arista from Arista website"""
 
 
-@ardl.group(no_args_is_help=True)
+@ardl.group(cls=AliasedGroup, no_args_is_help=True)
 @click.pass_context
-def info(ctx: click.Context) -> None:
+def info(ctx: click.Context, cls: click.Group = AliasedGroup) -> None:
     # pylint: disable=redefined-builtin
     """List information from Arista website"""
 
 
-@ardl.group(no_args_is_help=True)
+@ardl.group(cls=AliasedGroup, no_args_is_help=True)
 @click.pass_context
-def debug(ctx: click.Context) -> None:
+def debug(ctx: click.Context, cls: click.Group = AliasedGroup) -> None:
     # pylint: disable=redefined-builtin
     """Debug commands to work with ardl"""
 

--- a/eos_downloader/cli/utils.py
+++ b/eos_downloader/cli/utils.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+# pylint: disable=inconsistent-return-statements
+
+
+"""
+Extension for the python ``click`` module
+to provide a group or command with aliases.
+"""
+
+
+from typing import Any
+import click
+
+
+class AliasedGroup(click.Group):
+    """
+    Implements a subclass of Group that accepts a prefix for a command.
+    If there were a command called push, it would accept pus as an alias (so long as it was unique)
+    """
+    def get_command(self, ctx: click.Context, cmd_name: str) -> Any:
+        """Documentation to build"""
+        rv = click.Group.get_command(self, ctx, cmd_name)
+        if rv is not None:
+            return rv
+        matches = [x for x in self.list_commands(ctx)
+                   if x.startswith(cmd_name)]
+        if not matches:
+            return None
+        if len(matches) == 1:
+            return click.Group.get_command(self, ctx, matches[0])
+        ctx.fail(f"Too many matches: {', '.join(sorted(matches))}")
+
+    def resolve_command(self, ctx: click.Context, args: Any) -> Any:
+        """Documentation to build"""
+        # always return the full command name
+        _, cmd, args = super().resolve_command(ctx, args)
+        return cmd.name, cmd, args


### PR DESCRIPTION
Add support for automatic CLI aliasing

```bash
# Original command
❯ ardl info eos-versions -rtype m --branch 4.29
['4.29.4M', '4.29.3.1M', '4.29.3M']

# CMD shortcut
❯ ardl info eos -rtype m --branch 4.29
['4.29.4M', '4.29.3.1M', '4.29.3M']

❯ ardl in eos-versions -rtype m --branch 4.29
['4.29.4M', '4.29.3.1M', '4.29.3M']

❯ ardl i e -rtype m --branch 4.29
['4.29.4M', '4.29.3.1M', '4.29.3M']
```