### PR TITLE
bump: Version 0.8.2 -> 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eos_downloader"
-version = "v0.8.2"
+version = "v0.9.0"
 readme = "README.md"
 authors = [{ name = "Thomas Grimonet", email = "thomas.grimonet@gmail.com" }]
 maintainers = [
@@ -94,7 +94,7 @@ namespaces = false
 # Version
 ################################
 [tool.bumpver]
-current_version = "0.8.2"
+current_version = "0.9.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message  = "bump: Version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
## What's Changed

### Breaking Changes

* cut!: remove deprecated scripts by @titom73 in https://github.com/titom73/eos-downloader/pull/51

### Main 

* fix(ardl.cli): Implement `--version` as standard cli by @titom73 in https://github.com/titom73/eos-downloader/pull/64
* feat(cli): Add support for CLI shortcut by @titom73 in https://github.com/titom73/eos-downloader/pull/53
* doc: exemple to get latest version by @titom73 in https://github.com/titom73/eos-downloader/pull/65

### Other changes
* ci: Implement pre-commit validation by @titom73 in https://github.com/titom73/eos-downloader/pull/52
* doc: Add badges for code features by @titom73 in https://github.com/titom73/eos-downloader/pull/55
* bump: bump tox from 4.10.0 to 4.11.0 by @dependabot in https://github.com/titom73/eos-downloader/pull/54
* bump: bump tox from 4.11.0 to 4.11.1 by @dependabot in https://github.com/titom73/eos-downloader/pull/56
* bump: bump tox from 4.11.1 to 4.11.2 by @dependabot in https://github.com/titom73/eos-downloader/pull/57
* bump: bump tox from 4.11.2 to 4.11.3 by @dependabot in https://github.com/titom73/eos-downloader/pull/58
* bump: update rich requirement from ~=13.5.2 to >=13.5.2,<13.7.0 by @dependabot in https://github.com/titom73/eos-downloader/pull/63

**Full Changelog**: https://github.com/titom73/eos-downloader/compare/v0.8.2...v0.8.3