### PR TITLE
feat(cli): tag imge with latest when dowloaded with --latest option

### DIFF
--- a/eos_downloader/cli/get/commands.py
+++ b/eos_downloader/cli/get/commands.py
@@ -128,6 +128,7 @@ def eos(
     console = Console()
     # Get from Context
     token = ctx.obj["token"]
+    is_latest: bool = False
     if token is None or token == "":
         console.print(
             "❗ Token is unset ! Please configure ARISTA_TOKEN or use --token option",
@@ -156,6 +157,7 @@ def eos(
         my_download.authenticate()
 
     elif latest:
+        is_latest = True
         my_download = eos_downloader.eos.EOSDownloader(
             image=image_type,
             software="EOS",
@@ -180,7 +182,7 @@ def eos(
         my_download.download_local(file_path=output, checksum=True)
 
     if import_docker:
-        my_download.docker_import(image_name=docker_name)
+        my_download.docker_import(image_name=docker_name, is_latest=is_latest)
     console.print("✅  processing done !")
     sys.exit(0)
 

--- a/eos_downloader/eos.py
+++ b/eos_downloader/eos.py
@@ -137,8 +137,7 @@ class EOSDownloader(ObjectDownloader):
         selected_branch = EosVersion.from_str(BASE_BRANCH_STR)
         for branch in self._get_branches(with_rtype=rtype):
             branch = EosVersion.from_str(branch)
-            if branch > selected_branch:
-                selected_branch = branch
+            selected_branch = max(selected_branch, branch)
         return selected_branch
 
     def get_eos_versions(

--- a/eos_downloader/object_downloader.py
+++ b/eos_downloader/object_downloader.py
@@ -547,7 +547,9 @@ class ObjectDownloader:
         if noztp:
             self._disable_ztp(file_path=file_path)
 
-    def docker_import(self, image_name: str = "arista/ceos") -> None:
+    def docker_import(
+        self, image_name: str = "arista/ceos", is_latest: bool = False
+    ) -> None:
         """
         Import docker container to your docker server.
 
@@ -561,6 +563,9 @@ class ObjectDownloader:
         logger.info(f"Importing image {self.filename} to {docker_image}")
         console.print(f"🚀 Importing image {self.filename} to {docker_image}")
         os.system(f"$(which docker) import {self.filename} {docker_image}")
+        if is_latest:
+            console.print(f"🚀 Configuring {docker_image}:{self.version} to be latest")
+            os.system(f"$(which docker) tag {docker_image} {image_name}:latest")
         for filename in glob.glob(f"{self.filename}*"):
             try:
                 os.remove(filename)


### PR DESCRIPTION
Configure `latest` tag to docker cEOS image when using CLI option `--latest` 

```
❯ ardl get eos --image-type cEOS -l -rtype \M --import-docker
🪐 eos-downloader is starting...
    - Image Type: cEOS
    - Version: None
🔎  Searching file cEOS-lab-4.30.5M.tar.xz
    -> Found file at /support/download/EOS-USA/Active Releases/4.30/EOS-4.30.5M/cEOS-lab/cEOS-lab-4.30.5M.tar.xz
💾  Downloading cEOS-lab-4.30.5M.tar.xz ...
🚀  Running checksum validation
🔎  Searching file cEOS-lab-4.30.5M.tar.xz.sha512sum
    -> Found file at /support/download/EOS-USA/Active Releases/4.30/EOS-4.30.5M/cEOS-lab/cEOS-lab-4.30.5M.tar.xz.sha512sum
💾  Downloading cEOS-lab-4.30.5M.tar.xz.sha512sum ...
✅  Downloaded file is correct.
🚀 Importing image cEOS-lab-4.30.5M.tar.xz to arista/ceos:4.30.5M
sha256:f03d2ee2250675d1cc2b271a9d354ff864a2968e769663c925364ae5ac5ad4c9
🚀 Configuring arista/ceos:4.30.5M:4.30.5M to be latest
✅  processing done !

❯ docker images G arista/ceos
arista/ceos                                                                                          4.30.5M          f03d2ee22506   12 seconds ago   1.95GB
arista/ceos                                                                                          latest           f03d2ee22506   12 seconds ago   1.95GB
```