### PR TITLE
ci: Remove upper bounds for requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ dependencies = [
   "scp",
   "tqdm",
   "loguru",
-  "rich>=13.5.2,<13.8.0",
+  "rich>=13.5.2",
   "cvprac>=1.0.7",
-  "click~=8.1.6",
-  "click-help-colors~=0.9",
-  "pydantic>2.0.0,<3.0.0",
+  "click>=8.1.6",
+  "click-help-colors>=0.9",
+  "pydantic>2.0.0",
 ]
 keywords = ["eos_downloader", "Arista", "eos", "cvp", "network", "automation", "networking", "devops", "netdevops"]
 classifiers = [
@@ -51,8 +51,8 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 dev = [
-  "mypy==1.8.0",
-  "isort==5.13.2",
+  "mypy>=1.8.0",
+  "isort>=5.13.2",
   "mypy-extensions>=0.4.3",
   "pre-commit>=2.20.0",
   "pylint",
@@ -62,7 +62,7 @@ dev = [
   "pytest-html>=3.1.1",
   "pytest-metadata>=1.11.0",
   "pylint-pydantic>=0.2.4",
-  "tox~=4.11",
+  "tox>=4.11",
   "types-PyYAML",
   "types-paramiko",
   "types-requests",


### PR DESCRIPTION
# Description

Drinking the cool aid from here: https://iscinumpy.dev/post/bound-version-constraints/
eos-downloader is intended to be used as a library

* Removed upper cap on requirements (not dev)