### PR TITLE
Bump Docker images to latest Python 3x

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Ignore everything
+*
+
+# Allow files and directories
+!/eos_downloader/
+!/pyproject.toml
+!/LICENSE
+
+# Ignore unnecessary files inside allowed directories
+# This should go after the allowed directories
+**/*~
+**/*.log
+**/.DS_Store
+**/Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VER=3.10
+ARG PYTHON_VER=3
 
 FROM python:${PYTHON_VER}-slim
 

--- a/Dockerfile.docker
+++ b/Dockerfile.docker
@@ -1,4 +1,4 @@
-ARG PYTHON_VER=3.10
+ARG PYTHON_VER=3
 
 FROM python:${PYTHON_VER}-slim
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,25 @@
 CURRENT_DIR = $(shell pwd)
 
-DOCKER_NAME ?= titom73/eos-downloader
+DOCKER_NAME ?= ghcr.io/titom73/eos-downloader
 DOCKER_TAG ?= dev
 DOCKER_FILE ?= Dockerfile
-PYTHON_VER ?= 3.9
+PYTHON_VER ?= 3
+
+.PHONY: help
+help: ## Display help message
+	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: base
+base: ## Build a base image
+	docker build -t $(DOCKER_NAME):$(DOCKER_TAG) --build-arg DOCKER_VERSION=$(DOCKER_VERSION) -f $(DOCKER_FILE) .
+
+.PHONY: dnd
+dnd:  ## Build a docker in docker image
+	docker build -t $(DOCKER_NAME):dnd-$(DOCKER_TAG) --build-arg DOCKER_VERSION=$(DOCKER_VERSION) -f Dockerfile.docker .
 
 .PHONY: build
-build:
-	docker build -t $(DOCKER_NAME):$(DOCKER_TAG) --build-arg DOCKER_VERSION=$(DOCKER_VERSION) -f $(DOCKER_FILE) .
+build: base dnd  ## Build all dockers images (base and dnd)
+
+.PHONY: push
+push: ## Push the docker image to the registry
+	docker push $(DOCKER_NAME):$(DOCKER_TAG)


### PR DESCRIPTION
- **bump(docker): Use latest python:3 image as base reference**
- **make(docker): Implement basic dockerignore to reduce image footprint**
