### PR TITLE
feat(eos_downloader): Implement a command to download package with their remote path

### DIFF
--- a/docs/usage/path.md
+++ b/docs/usage/path.md
@@ -1,0 +1,38 @@
+# Download any arista package
+
+This command gives an option for advanced users to download any packages available on arista website and using the standard authentication mechanism.
+
+!!! warning
+    This command is for advanced user only
+
+```bash
+# Get a package from arista server
+ardl get path -s "/support/path/to/docker/image/cEOS-lab-4.32.3M.tar.xz"
+
+# Get a package from arista server and import into your docker engine
+ardl get path -s "/support/path/to/docker/image/cEOS-lab-4.32.3M.tar.xz" --import-docker
+
+# Get a package from arista server and import into your docker engine with specific image and version
+ardl get path -s "/support/path/to/docker/image/cEOS-lab-4.32.3M.tar.xz" --import-docker --docker-image arista/myceos --docker-version 4.32.3M
+```
+
+## ardl get path options
+
+```bash
+$ ardl get path --help
+Usage: ardl get path [OPTIONS]
+
+  Download image from Arista server using direct path.
+
+Options:
+  -s, --source TEXT   Image path to download from Arista Website
+  -o, --output PATH   Path to save downloaded package  [env var:
+                      ARISTA_GET_PATH_OUTPUT; default: .]
+  --import-docker     Import docker image to local docker  [env var:
+                      ARISTA_GET_PATH_IMPORT_DOCKER]
+  --docker-name TEXT  Docker image name  [env var:
+                      ARISTA_GET_PATH_DOCKER_NAME; default: arista/ceos:raw]
+  --docker-tag TEXT   Docker image tag  [env var: ARISTA_GET_PATH_DOCKER_TAG;
+                      default: dev]
+  --help              Show this message and exit.
+```

--- a/eos_downloader/cli/cli.py
+++ b/eos_downloader/cli/cli.py
@@ -83,6 +83,7 @@ def cli() -> None:
     # Load group commands for get
     get.add_command(get_commands.eos)
     get.add_command(get_commands.cvp)
+    get.add_command(get_commands.path)
 
     # Debug
     debug.add_command(debug_commands.xml)

--- a/eos_downloader/cli/get/commands.py
+++ b/eos_downloader/cli/get/commands.py
@@ -310,6 +310,7 @@ def cvp(
     show_envvar=True,
 )
 @click.pass_context
+# pylint: disable=too-many-branches
 def path(
     ctx: click.Context,
     output: str,
@@ -341,6 +342,10 @@ def path(
             console.print_exception(show_locals=True)
         else:
             console.print(f"\n[red]Exception raised: {e}[/red]")
+        return 1
+
+    if file_url is None:
+        console.print("File URL is set to None when we expect a string")
         return 1
 
     cli = SoftManager(dry_run=False)

--- a/eos_downloader/cli/get/utils.py
+++ b/eos_downloader/cli/get/utils.py
@@ -106,7 +106,7 @@ def download_files(
     """
 
     console.print(
-        f"Starting download for EOS version [green]{arista_dl_obj}[/green] for [blue]{format}[/blue] format."
+        f"Starting download for EOS version [green]{arista_dl_obj.version}[/green] for [blue]{arista_dl_obj.image_type}[/blue] format."
     )
     cli.downloads(arista_dl_obj, file_path=output, rich_interface=rich_interface)
     try:

--- a/eos_downloader/logics/arista_server.py
+++ b/eos_downloader/logics/arista_server.py
@@ -210,7 +210,7 @@ class AristaServer:
 
         logging.info(f"Getting XML data from server {self._session_server}")
         if self._session_id is None:
-            logger.debug("Not authenticated to server, start authentication process")
+            logging.debug("Not authenticated to server, start authentication process")
             self.authenticate()
         jsonpost = {"sessionCode": self._session_id}
         result = requests.post(
@@ -255,7 +255,7 @@ class AristaServer:
 
         logging.info(f"Getting download URL for {remote_file_path}")
         if self._session_id is None:
-            logger.debug("Not authenticated to server, start authentication process")
+            logging.debug("Not authenticated to server, start authentication process")
             self.authenticate()
         jsonpost = {"sessionCode": self._session_id, "filePath": remote_file_path}
         result = requests.post(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,6 +164,7 @@ nav:
   - Usage:
       - Get EOS package: usage/eos.md
       - Get CVP package: usage/cvp.md
+      - Get Any package: usage/path.md
       - Environment variables: usage/environment.md
       - Version information: usage/info.md
       - Software mapping: usage/mapping.md


### PR DESCRIPTION
## Overview

Add command to download file using its path on remote server. It can be applied for any type of package provided by Arista server

## Usage

```bash
ardl get raw -s "path/to/ser/ver" -o ~/downloads/
```

## Tasks

- [x] Implement docker import options
- [x] Update documentation

## Known limitations

- EFT packages are not supported
