### PR TITLE
cEOSarm support

### DIFF
--- a/eos_downloader/models/data.py
+++ b/eos_downloader/models/data.py
@@ -124,6 +124,7 @@ software_mapping = DataMapping(
         "2GB-INT": {"extension": "-INT.swi", "prepend": "EOS-2GB"},
         "cEOS": {"extension": ".tar.xz", "prepend": "cEOS-lab"},
         "cEOS64": {"extension": ".tar.xz", "prepend": "cEOS64-lab"},
+        "cEOSarm": {"extension": ".tar.xz", "prepend": "cEOSarm-lab"},
         "vEOS": {"extension": ".vmdk", "prepend": "vEOS"},
         "vEOS-lab": {"extension": ".vmdk", "prepend": "vEOS-lab"},
         "EOS-2GB": {"extension": ".swi", "prepend": "EOS-2GB"},


### PR DESCRIPTION
I added a new line to the data.py file to match the Newest release of cEOSarm in 4.34.1F
My branch was tested and it successfully downloaded the cEOSarm file.

![image](https://github.com/user-attachments/assets/d26dedfd-b634-4ec9-9a15-70ef2330680f)
