### PR TITLE
feat: Add support to download .atswi CVP image

### DIFF
--- a/eos_downloader/models/data.py
+++ b/eos_downloader/models/data.py
@@ -116,6 +116,7 @@ software_mapping = DataMapping(
         "ova": {"extension": ".ova", "prepend": "cvp"},
         "rpm": {"extension": "", "prepend": "cvp-rpm-installer"},
         "kvm": {"extension": "-kvm.tgz", "prepend": "cvp"},
+        "atswi": {"extension": ".atswi", "prepend": "cvp"},
         "upgrade": {"extension": ".tgz", "prepend": "cvp-upgrade"},
     },
     EOS={


### PR DESCRIPTION
Add support to downoad .atswi CVP files from arista.com (new CVP format for CVA running a version above 7.0.0). 