### PR TITLE
chore: Implement CODEOWNERS for PR Review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @titom73 will be requested for
+# review when someone opens a pull request.
+*       @titom73
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "titom73"
     labels:
       - 'dependencies'
     pull-request-branch-name:
@@ -28,8 +26,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "titom73"
     labels:
       - 'CI'
     commit-message:


### PR DESCRIPTION
Implement CODEOWNERS and remove reviewers field from dependabot configuration

```yaml
updates:
  - package-ecosystem: "pip"
    reviewers:
      - "titom73"
```