### PR TITLE
cut: Remove Python 3.8 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,13 +52,12 @@ classifiers = [
   'Operating System :: OS Independent',
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
-  'Programming Language :: Python :: 3.8',
   'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3 :: Only',
   'Programming Language :: Python :: Implementation :: PyPy',
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
isort version 6.1.0 requires Python 3.9 or higher

Python 3.8 won't work. Therefore adjusting minimal Python version.