### PR TITLE
chore(actions): Update release notes generator to use kind: labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,69 +1,20 @@
 changelog:
   exclude:
     labels:
-      - kind:test(eos_downloader)
-      - kind:ci(eos_downloader)
-      - kind:test(eos_downloader.cli)
-      - kind:ci(eos_downloader.cli)
-      - kind:test(requirements)
-      - kind:ci(requirements)
-      - kind:test(actions)
-      - kind:ci(actions)
       - kind:test
       - kind:ci
   categories:
     - title: Breaking Changes
       labels:
-        - kind:feat(eos_downloader)!
-        - kind:feat(eos_downloader.cli)!
-        - kind:feat(requirements)!
-        - kind:feat(actions)!
-        - kind:fix(eos_downloader)!
-        - kind:fix(eos_downloader.cli)!
-        - kind:fix(requirements)!
-        - kind:fix(actions)!
-        - kind:cut(eos_downloader)!
-        - kind:cut(eos_downloader.cli)!
-        - kind:cut(requirements)!
-        - kind:cut(actions)!
-        - kind:revert(eos_downloader)!
-        - kind:revert(eos_downloader.cli)!
-        - kind:revert(requirements)!
-        - kind:revert(actions)!
-        - kind:refactor(eos_downloader)!
-        - kind:refactor(eos_downloader.cli)!
-        - kind:refactor(requirements)!
-        - kind:refactor(actions)!
-        - kind:bump(eos_downloader)!
-        - kind:bump(eos_downloader.cli)!
-        - kind:bump(requirements)!
-        - kind:bump(actions)!
-        - kind:feat!
-        - kind:fix!
-        - kind:cut!
-        - kind:revert!
-        - kind:refactor!
-        - kind:bump!
+        - compat:breaking
     - title: New features and enhancements
       labels:
-        - kind:feat(eos_downloader)
-        - kind:feat(eos_downloader.cli)
-        - kind:feat(requirements)
-        - kind:feat(actions)
         - kind:feat
     - title: Fixed issues
       labels:
-        - kind:fix(eos_downloader)
-        - kind:fix(eos_downloader.cli)
-        - kind:fix(requirements)
-        - kind:fix(actions)
         - kind:fix
     - title: Documentation
       labels:
-        - kind:doc(eos_downloader)
-        - kind:doc(eos_downloader.cli)
-        - kind:doc(requirements)
-        - kind:doc(actions)
         - kind:doc
     - title: Other Changes
       labels:

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -96,11 +96,19 @@ jobs:
           TYPE=$(echo "$PR_TITLE" | grep -oE '^(feat|fix|cut|doc|ci|bump|test|refactor|revert|make|chore)' || echo "")
           # Extract scope (content within parentheses)
           SCOPE=$(echo "$PR_TITLE" | grep -oE '\(([^)]+)\)' | tr -d '()' || echo "")
+          # Check for breaking change marker (!)
+          if echo "$PR_TITLE" | grep -qE '!:'; then
+            BREAKING="true"
+          else
+            BREAKING="false"
+          fi
 
           echo "Parsed TYPE: $TYPE"
           echo "Parsed SCOPE: $SCOPE"
+          echo "Parsed BREAKING: $BREAKING"
           echo "type=$TYPE" >> $GITHUB_OUTPUT
           echo "scope=$SCOPE" >> $GITHUB_OUTPUT
+          echo "breaking=$BREAKING" >> $GITHUB_OUTPUT
 
       - name: Create and add kind label
         if: steps.parse.outputs.type != ''
@@ -138,7 +146,28 @@ jobs:
           gh pr edit "$PR_NUMBER" \
             --add-label "scope:$SCOPE_NAME"
 
+      - name: Create and add breaking change label
+        if: steps.parse.outputs.breaking == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Create label if it doesn't exist
+          gh label create "compat:breaking" \
+            --description "Breaking change - impacts compatibility" \
+            --color "D93F0B" \
+            --force || true
+
+          # Add label to PR
+          gh pr edit "$PR_NUMBER" \
+            --add-label "compat:breaking"
+
       - name: Summary
+        env:
+          KIND_TYPE: ${{ steps.parse.outputs.type }}
+          SCOPE_NAME: ${{ steps.parse.outputs.scope }}
+          IS_BREAKING: ${{ steps.parse.outputs.breaking }}
         run: |
           echo "### 🏷️ PR Labeling Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -152,6 +181,6 @@ jobs:
           else
             echo "- ℹ️ No scope found in PR title" >> $GITHUB_STEP_SUMMARY
           fi
-        env:
-          KIND_TYPE: ${{ steps.parse.outputs.type }}
-          SCOPE_NAME: ${{ steps.parse.outputs.scope }}
+          if [ "$IS_BREAKING" = "true" ]; then
+            echo "- 🚨 Added **compat:breaking** label (breaking change detected)" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
- Parse types and scopes dynamically from pr-triage.yml workflow
- Remove legacy rn: label references (not used in this repo)
- Generate .github/release.yml (correct GitHub location)
- Support both scoped (kind:feat(scope)) and unscoped (kind:feat) labels
- Extract 11 types and 4 scopes from workflow configuration
- Maintain backward compatibility with fallback defaults
