### PR TITLE
chore(actions): Add Docker Buildx setup for multi-platform builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Docker meta for TAG
       id: meta
       uses: docker/metadata-action@v5
@@ -93,6 +96,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v5
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Docker meta for TAG
       id: meta


### PR DESCRIPTION
- Add docker/setup-buildx-action@v3 to both docker jobs
- Fixes 'Multi-platform build is not supported for the docker driver' error
- Enables linux/amd64 and linux/arm64 platform builds
