### PR TITLE
feat(eos_downloader.cli): grouped rich/plain progress reporter with concurrency

### DIFF
--- a/docs/dev-notes/uv-installation-modes.md
+++ b/docs/dev-notes/uv-installation-modes.md
@@ -20,7 +20,7 @@ uv sync
 **Packages installed**: 31 packages (core dependencies only)
 
 **Includes**:
-- Core application dependencies (click, requests, rich, loguru, tqdm, pydantic, etc.)
+- Core application dependencies (typer, requests, rich, loguru, pydantic, etc.)
 - Runtime requirements for CLI commands (ardl, lard)
 - Essential libraries (cryptography, paramiko, cvprac)
 

--- a/eos_downloader/cli/get/commands.py
+++ b/eos_downloader/cli/get/commands.py
@@ -18,6 +18,7 @@ from typing import Optional
 import typer
 
 from eos_downloader.models.data import RTYPE_FEATURE
+from eos_downloader.models.types import ProgressMode
 from eos_downloader.logics.download import SoftManager
 from eos_downloader.logics.arista_server import AristaServer
 from eos_downloader.logics.arista_xml_server import (
@@ -117,6 +118,11 @@ def eos(
         help="Force download/import even if cached files or Docker images exist",
         show_envvar=True,
     ),
+    no_progress: bool = typer.Option(
+        False,
+        "--no-progress",
+        help="Disable the download progress display (useful for CI/non-TTY)",
+    ),
     containerlab_topology: Optional[Path] = typer.Option(
         None,
         "--containerlab-topology",
@@ -130,6 +136,7 @@ def eos(
     """Download EOS image from Arista server."""
     # pylint: disable=unused-variable
     console, token, debug, log_level = initialize(ctx)
+    progress: ProgressMode = "none" if no_progress else "auto"
 
     if containerlab_topology is not None:
         if version is not None or latest or branch is not None:
@@ -156,6 +163,7 @@ def eos(
             force=force,
             debug=debug,
             skip_download=skip_download,
+            progress=progress,
         )
 
     version = search_version(
@@ -176,16 +184,16 @@ def eos(
             console.print(f"\n[red]Exception raised: {exc}[/red]")
         raise typer.Exit(1) from exc
 
-    cli = SoftManager(dry_run=dry_run, force_download=force)
+    cli = SoftManager(dry_run=dry_run, force_download=force, console=console)
 
     if not skip_download:
         if not eve_ng:
             download_files(
-                console, cli, eos_dl_obj, output, rich_interface=True, debug=debug
+                console, cli, eos_dl_obj, output, debug=debug, progress=progress
             )
         else:
             try:
-                cli.provision_eve(eos_dl_obj, noztp=True)
+                cli.provision_eve(eos_dl_obj, noztp=True, progress=progress)
             except Exception as e:
                 if debug:
                     console.print_exception(show_locals=True)
@@ -251,10 +259,16 @@ def cvp(
         help="Force download even if cached files exist",
         show_envvar=True,
     ),
+    no_progress: bool = typer.Option(
+        False,
+        "--no-progress",
+        help="Disable the download progress display (useful for CI/non-TTY)",
+    ),
 ) -> int:
     """Download CVP image from Arista server."""
     # pylint: disable=unused-variable
     console, token, debug, log_level = initialize(ctx)
+    progress: ProgressMode = "none" if no_progress else "auto"
 
     if version is not None:
         console.print(
@@ -301,14 +315,14 @@ def cvp(
             console.print(f"\n[red]Exception raised: {e}[/red]")
         raise typer.Exit(1)
 
-    cli = SoftManager(dry_run=dry_run, force_download=force)
+    cli = SoftManager(dry_run=dry_run, force_download=force, console=console)
     download_files(
         console,
         cli,
         cvp_dl_obj,
         output,
-        rich_interface=True,
         debug=debug,
+        progress=progress,
         checksum_format="md5sum",
     )
 
@@ -356,9 +370,15 @@ def path(
         help="Force download/import even if cached files or Docker images exist",
         show_envvar=True,
     ),
+    no_progress: bool = typer.Option(
+        False,
+        "--no-progress",
+        help="Disable the download progress display (useful for CI/non-TTY)",
+    ),
 ) -> int:
     """Download image from Arista server using direct path."""
     console, token, debug, log_level = initialize(ctx)
+    progress: ProgressMode = "none" if no_progress else "auto"
 
     if source is None:
         console.print("[red]Source is not set correctly ![/red]")
@@ -389,10 +409,12 @@ def path(
     # At this point, mypy knows file_url is not None due to the check above
     assert file_url is not None  # Type assertion for mypy
 
-    cli = SoftManager(dry_run=False, force_download=force)
+    cli = SoftManager(dry_run=False, force_download=force, console=console)
 
     try:
-        cli.download_file(file_url, output, filename=filename, force=force)
+        cli.download_file(
+            file_url, output, filename=filename, force=force, progress=progress
+        )
     except Exception as e:
         if debug:
             console.print_exception(show_locals=True)

--- a/eos_downloader/cli/get/utils.py
+++ b/eos_downloader/cli/get/utils.py
@@ -15,7 +15,7 @@ from rich.console import Console
 
 from eos_downloader.cli.utils import console_configuration
 from eos_downloader.models.data import RTYPE_FEATURE, RTYPES
-from eos_downloader.models.types import ReleaseType
+from eos_downloader.models.types import ProgressMode, ReleaseType
 from eos_downloader.logics.arista_xml_server import (
     AristaXmlQuerier,
     AristaXmlObjects,
@@ -161,8 +161,8 @@ def download_files(
     cli: Any,
     arista_dl_obj: AristaXmlObjects,
     output: str,
-    rich_interface: bool,
     debug: bool,
+    progress: ProgressMode = "auto",
     checksum_format: str = "sha512sum",
 ) -> None:
     """Downloads EOS files and verifies their checksums.
@@ -177,10 +177,10 @@ def download_files(
         The EOS download object containing version and filename information.
     output : str
         The output directory where the files will be saved.
-    rich_interface : bool
-        Flag to indicate if rich interface should be used.
     debug : bool
         Flag to indicate if debug information should be printed.
+    progress : ProgressMode, optional
+        Progress rendering mode: "auto" (default), "rich", "plain" or "none".
     checksum_format : str, optional
         The checksum format to use for verification. Defaults to "sha512sum".
 
@@ -197,7 +197,7 @@ def download_files(
     try:
         # downloads() returns a tuple (path, was_cached)
         _file_path, was_cached = cli.downloads(
-            arista_dl_obj, file_path=output, rich_interface=rich_interface
+            arista_dl_obj, file_path=output, progress=progress
         )
         cli.checksum(checksum_format)
 
@@ -320,6 +320,7 @@ def download_from_containerlab_topology(  # pylint: disable=too-many-branches
     force: bool,
     debug: bool,
     skip_download: bool,
+    progress: ProgressMode = "auto",
 ) -> int:
     """Download all cEOS images referenced in a containerlab topology file.
 
@@ -347,6 +348,8 @@ def download_from_containerlab_topology(  # pylint: disable=too-many-branches
         If True, show detailed error information.
     skip_download : bool
         If True, skip the download step (useful for import-only).
+    progress : ProgressMode, optional
+        Progress rendering mode: "auto" (default), "rich", "plain" or "none".
 
     Returns
     -------
@@ -382,12 +385,12 @@ def download_from_containerlab_topology(  # pylint: disable=too-many-branches
             failures.append(version)
             continue
 
-        cli = SoftManager(dry_run=dry_run, force_download=force)
+        cli = SoftManager(dry_run=dry_run, force_download=force, console=console)
 
         if not skip_download:
             try:
                 download_files(
-                    console, cli, eos_dl_obj, output, rich_interface=True, debug=debug
+                    console, cli, eos_dl_obj, output, debug=debug, progress=progress
                 )
             except Exception as e:  # pylint: disable=broad-exception-caught
                 logger.error(f"Failed to download {version}: {e}")

--- a/eos_downloader/helpers/__init__.py
+++ b/eos_downloader/helpers/__init__.py
@@ -31,6 +31,7 @@ Functions
 # pylint: disable=unused-argument
 # pylint: disable=too-few-public-methods
 
+import os
 import signal
 import time
 from abc import ABC, abstractmethod
@@ -66,11 +67,15 @@ DownloadItem = Tuple[str, str, str]
 
 @contextmanager
 def sigint_guard(done_event: Event) -> Iterator[None]:
-    """Temporarily route ``SIGINT`` to a done event for the duration of a block.
+    """Route ``SIGINT`` to a done event, then defer to the previous handler.
 
-    The previous handler is saved and restored on exit, so importing this module
-    has no process-wide side effect. If a handler cannot be installed (e.g. the
-    caller is not in the main thread), the block still runs without interception.
+    On Ctrl+C the workers are asked to stop promptly (via ``done_event``) and the
+    previous handler is then invoked so the interruption still propagates — a
+    default handler raises ``KeyboardInterrupt`` in the main thread rather than
+    letting the download look like a clean completion. The previous handler is
+    saved and restored on exit, so importing this module has no process-wide side
+    effect. If a handler cannot be installed (e.g. the caller is not in the main
+    thread), the block still runs without interception.
 
     Parameters
     ----------
@@ -83,9 +88,19 @@ def sigint_guard(done_event: Event) -> Iterator[None]:
     """
     previous: Any = None
     installed = False
+
+    def handler(signum: int, frame: Any) -> None:
+        done_event.set()
+        if callable(previous):
+            previous(signum, frame)
+        elif previous == signal.SIG_DFL:
+            # Reproduce the default behaviour: raise KeyboardInterrupt.
+            signal.default_int_handler(signum, frame)
+        # signal.SIG_IGN: intentionally leave the signal ignored.
+
     try:
         previous = signal.getsignal(signal.SIGINT)
-        signal.signal(signal.SIGINT, lambda signum, frame: done_event.set())
+        signal.signal(signal.SIGINT, handler)
         installed = True
     except ValueError:
         # Not in the main thread: leave signal handling untouched.
@@ -182,24 +197,40 @@ class RichReporter(DownloadReporter):
     def __exit__(self, *exc_info: Any) -> None:
         self._live.stop()
 
+    def _total_completed(self) -> float:
+        """Return the bytes already counted on the Total task."""
+        task = next((t for t in self._progress.tasks if t.id == self._total_task), None)
+        return task.completed if task is not None else 0
+
     def add_file(self, name: str, total: Optional[int]) -> TaskID:
         task_id = self._progress.add_task(name, total=total)
         with self._lock:
             if total is None:
-                # A file of unknown size makes the aggregate indeterminate.
-                self._total_indeterminate = True
+                if not self._total_indeterminate:
+                    # A file of unknown size makes the aggregate indeterminate.
+                    # ``Progress.update(total=None)`` means "leave unchanged", so
+                    # the Total task is re-created (public API), preserving the
+                    # bytes already counted.
+                    completed = self._total_completed()
+                    self._progress.remove_task(self._total_task)
+                    self._total_task = self._progress.add_task(
+                        "Total", total=None, completed=completed
+                    )
+                    self._total_indeterminate = True
             else:
                 self._total_known += total
-            # ``Progress.update(total=None)`` means "leave unchanged", so the
-            # indeterminate total is set on the Task directly.
-            self._progress._tasks[  # pylint: disable=protected-access
-                self._total_task
-            ].total = (None if self._total_indeterminate else self._total_known)
+                if not self._total_indeterminate:
+                    self._progress.update(self._total_task, total=self._total_known)
         return task_id
 
     def advance(self, handle: TaskID, n_bytes: int) -> None:
         self._progress.update(handle, advance=n_bytes)
-        self._progress.update(self._total_task, advance=n_bytes)
+        try:
+            self._progress.update(self._total_task, advance=n_bytes)
+        except KeyError:
+            # The Total task may be mid-recreation (an unknown-size file is
+            # registering and switching the aggregate to indeterminate).
+            pass
 
     def complete(self, handle: TaskID) -> None:
         task = next((t for t in self._progress.tasks if t.id == handle), None)
@@ -320,6 +351,11 @@ def _stream_to_file(
     -------
     bool
         True if the download was interrupted, False if it completed.
+
+    Raises
+    ------
+    requests.HTTPError
+        If the server returns an error status code.
     """
     url, dest_path, display_name = item
     response = requests.get(
@@ -328,15 +364,34 @@ def _stream_to_file(
         timeout=5,
         headers=eos_downloader.defaults.DEFAULT_REQUEST_HEADERS,
     )
-    content_length = response.headers.get("Content-Length")
-    total = int(content_length) if content_length is not None else None
-    handle = reporter.add_file(display_name, total)
-    with open(dest_path, "wb") as dest_file:
-        for data in response.iter_content(chunk_size=block_size):
-            dest_file.write(data)
-            reporter.advance(handle, len(data))
-            if done_event.is_set():
-                return True
+    interrupted = False
+    try:
+        # Surface HTTP errors before writing an error page to disk.
+        response.raise_for_status()
+        content_length = response.headers.get("Content-Length")
+        total = int(content_length) if content_length is not None else None
+        handle = reporter.add_file(display_name, total)
+        with open(dest_path, "wb") as dest_file:
+            for data in response.iter_content(chunk_size=block_size):
+                if not data:
+                    # Skip empty keep-alive chunks so they don't inflate progress.
+                    continue
+                dest_file.write(data)
+                reporter.advance(handle, len(data))
+                if done_event.is_set():
+                    interrupted = True
+                    break
+    finally:
+        response.close()
+
+    if interrupted:
+        # Drop the partial file so a later run does not mistake it for a
+        # complete, cached download.
+        try:
+            os.remove(dest_path)
+        except OSError:
+            pass
+        return True
     reporter.complete(handle)
     return False
 

--- a/eos_downloader/helpers/__init__.py
+++ b/eos_downloader/helpers/__init__.py
@@ -1,196 +1,379 @@
 # flake8: noqa: F811
-"""A module for managing file downloads with progress tracking in the console.
+"""Download progress reporting for the console.
 
-This module provides functionality for downloading files with visual progress indicators
-using the Rich library. It includes a signal handler for graceful interruption and
-a DownloadProgressBar class for concurrent file downloads with progress tracking.
+This module renders the progress of file downloads through a small
+:class:`DownloadReporter` abstraction with two concrete implementations that are
+selected automatically depending on whether output is an interactive terminal:
+
+- :class:`RichReporter` — a grouped, animated display (one Rich ``Progress``
+  shared by every file of a download, wrapped in a titled ``Panel`` with an
+  aggregated *Total* bar). Used on a TTY.
+- :class:`PlainReporter` — plain ``loguru`` log lines with no ANSI escape
+  sequences. Used in CI / non-interactive output.
+
+A :class:`NoopReporter` is used when progress rendering is disabled. The helper
+:func:`download_files_concurrently` downloads the files of a single download in
+parallel while updating one shared reporter.
 
 Classes
 -------
-    DownloadProgressBar: A class that provides visual progress tracking for file downloads.
+    DownloadReporter: Abstract progress reporter interface.
+    RichReporter: Animated grouped display for interactive terminals.
+    PlainReporter: ANSI-free log-line reporter for non-TTY / CI.
+    NoopReporter: Reporter that renders nothing.
 
 Functions
--------
-    handle_sigint: Signal handler for SIGINT (Ctrl+C) to enable graceful termination.
-    console (Console): Rich Console instance for output rendering.
-    done_event (Event): Threading Event used for signaling download interruption.
+---------
+    resolve_reporter: Build the concrete reporter for a progress mode + console.
+    download_files_concurrently: Download several files in parallel under a reporter.
 """
 
 # pylint: disable=unused-argument
 # pylint: disable=too-few-public-methods
 
-import os.path
 import signal
+import time
+from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
-from threading import Event
-from typing import Any, Iterable
+from contextlib import contextmanager
+from threading import Event, Lock
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
 
 import requests
+from loguru import logger
 from rich.console import Console
-
-# from eos_downloader.console.client import DownloadProgressBar
+from rich.filesize import decimal
+from rich.live import Live
+from rich.panel import Panel
 from rich.progress import (
     BarColumn,
     DownloadColumn,
     Progress,
+    SpinnerColumn,
     TaskID,
+    TaskProgressColumn,
     TextColumn,
-    TimeElapsedColumn,
+    TimeRemainingColumn,
     TransferSpeedColumn,
 )
 
 import eos_downloader.defaults
+from eos_downloader.models.types import ProgressMode
+
+# Files that make up a single download, as (url, destination_path, display_name).
+DownloadItem = Tuple[str, str, str]
 
 
-console = Console()
-done_event = Event()
+@contextmanager
+def sigint_guard(done_event: Event) -> Iterator[None]:
+    """Temporarily route ``SIGINT`` to a done event for the duration of a block.
 
-
-def handle_sigint(signum: Any, frame: Any) -> None:
-    """
-    Signal handler for SIGINT (Ctrl+C).
-
-    This function sets the done_event flag when SIGINT is received,
-    allowing for graceful termination of the program.
+    The previous handler is saved and restored on exit, so importing this module
+    has no process-wide side effect. If a handler cannot be installed (e.g. the
+    caller is not in the main thread), the block still runs without interception.
 
     Parameters
     ----------
-    signum : Any
-        Signal number.
-    frame : Any
-        Current stack frame object.
+    done_event : Event
+        Event set when ``SIGINT`` (Ctrl+C) is received, signalling workers to stop.
+
+    Yields
+    ------
+    None
+    """
+    previous: Any = None
+    installed = False
+    try:
+        previous = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, lambda signum, frame: done_event.set())
+        installed = True
+    except ValueError:
+        # Not in the main thread: leave signal handling untouched.
+        installed = False
+    try:
+        yield
+    finally:
+        if installed:
+            signal.signal(signal.SIGINT, previous)
+
+
+class DownloadReporter(ABC):
+    """Abstract progress reporter for file downloads.
+
+    A reporter is a context manager: entering starts the display (if any) and
+    exiting stops it. Each file is registered with :meth:`add_file`, streamed
+    with :meth:`advance`, and finalised with :meth:`complete`.
+    """
+
+    def __enter__(self) -> "DownloadReporter":
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        return None
+
+    @abstractmethod
+    def add_file(self, name: str, total: Optional[int]) -> Any:
+        """Register a file and return an opaque handle used for later updates."""
+
+    @abstractmethod
+    def advance(self, handle: Any, n_bytes: int) -> None:
+        """Report that ``n_bytes`` more bytes of ``handle`` have been written."""
+
+    @abstractmethod
+    def complete(self, handle: Any) -> None:
+        """Mark the file identified by ``handle`` as finished."""
+
+
+class NoopReporter(DownloadReporter):
+    """Reporter that renders nothing (used for ``progress="none"``)."""
+
+    def add_file(self, name: str, total: Optional[int]) -> Any:
+        return None
+
+    def advance(self, handle: Any, n_bytes: int) -> None:
+        return None
+
+    def complete(self, handle: Any) -> None:
+        return None
+
+
+class RichReporter(DownloadReporter):
+    """Animated grouped display for interactive terminals.
+
+    All files share a single Rich ``Progress`` rendered inside a titled ``Panel``
+    via ``Live``, alongside an aggregated *Total* task.
+
+    Parameters
+    ----------
+    console : Console
+        The shared Rich console to render on.
+    title : str
+        Panel title.
+    """
+
+    def __init__(self, console: Console, title: str = "Downloading") -> None:
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(bar_width=None),
+            TaskProgressColumn(),
+            "•",
+            DownloadColumn(),
+            "•",
+            TransferSpeedColumn(),
+            "•",
+            TimeRemainingColumn(),
+            console=console,
+        )
+        self._live = Live(
+            Panel(self._progress, title=title, border_style="blue"),
+            console=console,
+            refresh_per_second=10,
+        )
+        self._total_task = self._progress.add_task("Total", total=0)
+        self._total_known = 0
+        self._total_indeterminate = False
+        self._lock = Lock()
+
+    def __enter__(self) -> "RichReporter":
+        self._live.start()
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self._live.stop()
+
+    def add_file(self, name: str, total: Optional[int]) -> TaskID:
+        task_id = self._progress.add_task(name, total=total)
+        with self._lock:
+            if total is None:
+                # A file of unknown size makes the aggregate indeterminate.
+                self._total_indeterminate = True
+            else:
+                self._total_known += total
+            # ``Progress.update(total=None)`` means "leave unchanged", so the
+            # indeterminate total is set on the Task directly.
+            self._progress._tasks[  # pylint: disable=protected-access
+                self._total_task
+            ].total = (None if self._total_indeterminate else self._total_known)
+        return task_id
+
+    def advance(self, handle: TaskID, n_bytes: int) -> None:
+        self._progress.update(handle, advance=n_bytes)
+        self._progress.update(self._total_task, advance=n_bytes)
+
+    def complete(self, handle: TaskID) -> None:
+        task = next((t for t in self._progress.tasks if t.id == handle), None)
+        if task is not None and task.total is not None:
+            # Snap the bar to 100% even if the reported total was approximate.
+            self._progress.update(handle, completed=task.total)
+
+
+class PlainReporter(DownloadReporter):
+    """ANSI-free reporter emitting ``loguru`` lifecycle lines (non-TTY / CI).
+
+    For each file: a start line (name + size), a progress line at every 10%
+    milestone, and a completion line (size, duration, average speed).
+    """
+
+    _MILESTONE_STEP = 10
+
+    def __init__(self) -> None:
+        self._files: Dict[int, Dict[str, Any]] = {}
+        self._counter = 0
+        self._lock = Lock()
+
+    def add_file(self, name: str, total: Optional[int]) -> int:
+        with self._lock:
+            handle = self._counter
+            self._counter += 1
+        self._files[handle] = {
+            "name": name,
+            "total": total,
+            "downloaded": 0,
+            "next_milestone": self._MILESTONE_STEP,
+            "start": time.monotonic(),
+        }
+        size = decimal(total) if total else "unknown size"
+        logger.info(f"Downloading {name} ({size})")
+        return handle
+
+    def advance(self, handle: int, n_bytes: int) -> None:
+        info = self._files[handle]
+        info["downloaded"] += n_bytes
+        total = info["total"]
+        if not total:
+            return
+        pct = info["downloaded"] * 100 // total
+        while info["next_milestone"] <= 90 and pct >= info["next_milestone"]:
+            logger.info(
+                f"{info['name']}: {info['next_milestone']}% "
+                f"({decimal(info['downloaded'])}/{decimal(total)})"
+            )
+            info["next_milestone"] += self._MILESTONE_STEP
+
+    def complete(self, handle: int) -> None:
+        info = self._files[handle]
+        duration = time.monotonic() - info["start"]
+        speed = info["downloaded"] / duration if duration > 0 else 0
+        logger.info(
+            f"{info['name']}: done in {duration:.1f}s "
+            f"({decimal(info['downloaded'])}, {decimal(int(speed))}/s)"
+        )
+
+
+def resolve_reporter(
+    mode: ProgressMode,
+    console: Console,
+    *,
+    title: str = "Downloading",
+) -> DownloadReporter:
+    """Build the concrete reporter for a progress ``mode`` and ``console``.
+
+    Parameters
+    ----------
+    mode : ProgressMode
+        One of ``"auto"``, ``"rich"``, ``"plain"``, ``"none"``. ``"auto"`` picks
+        the rich reporter on an interactive terminal and the plain one otherwise.
+    console : Console
+        The shared Rich console (its ``is_terminal`` drives ``"auto"``).
+    title : str
+        Panel title for the rich reporter.
+
+    Returns
+    -------
+    DownloadReporter
+        The reporter matching the requested mode.
+    """
+    if mode == "none":
+        return NoopReporter()
+    if mode == "rich":
+        use_rich = True
+    elif mode == "plain":
+        use_rich = False
+    else:  # "auto"
+        use_rich = console.is_terminal
+    if use_rich:
+        return RichReporter(console, title=title)
+    return PlainReporter()
+
+
+def _stream_to_file(
+    item: DownloadItem,
+    reporter: DownloadReporter,
+    done_event: Event,
+    block_size: int = 1024,
+) -> bool:
+    """Stream one file to disk while updating ``reporter``.
+
+    Parameters
+    ----------
+    item : DownloadItem
+        ``(url, destination_path, display_name)`` triple.
+    reporter : DownloadReporter
+        Reporter receiving progress updates for this file.
+    done_event : Event
+        When set (e.g. by Ctrl+C), the download stops early.
+    block_size : int, optional
+        Chunk size in bytes. Defaults to 1024.
+
+    Returns
+    -------
+    bool
+        True if the download was interrupted, False if it completed.
+    """
+    url, dest_path, display_name = item
+    response = requests.get(
+        url,
+        stream=True,
+        timeout=5,
+        headers=eos_downloader.defaults.DEFAULT_REQUEST_HEADERS,
+    )
+    content_length = response.headers.get("Content-Length")
+    total = int(content_length) if content_length is not None else None
+    handle = reporter.add_file(display_name, total)
+    with open(dest_path, "wb") as dest_file:
+        for data in response.iter_content(chunk_size=block_size):
+            dest_file.write(data)
+            reporter.advance(handle, len(data))
+            if done_event.is_set():
+                return True
+    reporter.complete(handle)
+    return False
+
+
+def download_files_concurrently(
+    items: Iterable[DownloadItem],
+    reporter: DownloadReporter,
+    *,
+    max_workers: int = 4,
+    block_size: int = 1024,
+) -> None:
+    """Download several files in parallel, updating a single shared reporter.
+
+    Parameters
+    ----------
+    items : Iterable[DownloadItem]
+        The files to download as ``(url, destination_path, display_name)`` triples.
+    reporter : DownloadReporter
+        The shared reporter; entered once around the whole batch.
+    max_workers : int, optional
+        Maximum number of concurrent downloads. Defaults to 4.
+    block_size : int, optional
+        Chunk size in bytes. Defaults to 1024.
 
     Returns
     -------
     None
     """
-    done_event.set()
-
-
-signal.signal(signal.SIGINT, handle_sigint)
-
-
-class DownloadProgressBar:
-    """A progress bar for downloading files.
-
-    This class provides a visual progress indicator for file downloads using the Rich library.
-    It supports downloading multiple files concurrently with a progress bar showing download
-    speed, completion percentage, and elapsed time.
-
-    Attributes
-    ----------
-    progress : Progress
-        A Rich Progress instance configured with custom columns for displaying download information.
-
-    Examples
-    --------
-    >>> downloader = DownloadProgressBar()
-    >>> urls = ['http://example.com/file1.zip', 'http://example.com/file2.zip']
-    >>> downloader.download(urls, '/path/to/destination')
-    """
-
-    def __init__(self) -> None:
-        self.progress = Progress(
-            TextColumn(
-                "💾  Downloading [bold blue]{task.fields[filename]}", justify="right"
-            ),
-            BarColumn(bar_width=None),
-            "[progress.percentage]{task.percentage:>3.1f}%",
-            "•",
-            TransferSpeedColumn(),
-            "•",
-            DownloadColumn(),
-            "•",
-            TimeElapsedColumn(),
-            "•",
-            console=console,
-        )
-
-    def _copy_url(
-        self, task_id: TaskID, url: str, path: str, block_size: int = 1024
-    ) -> bool:
-        """Download a file from a URL and save it to a local path with progress tracking.
-
-        This method performs a streaming download of a file from a given URL, saving it to the
-        specified local path while updating a progress bar. The download can be interrupted via
-        a done event.
-
-        Parameters
-        ----------
-        task_id : TaskID
-            Identifier for the progress tracking task.
-        url : str
-            URL to download the file from.
-        path : str
-            Local path where the file should be saved.
-        block_size : int, optional
-            Size of chunks to download at a time. Defaults to 1024 bytes.
-
-        Returns
-        -------
-        bool
-            True if download was interrupted by done_event, False if completed successfully.
-
-        Raises
-        ------
-        requests.exceptions.RequestException
-            If the download request fails.
-        IOError
-            If there are issues writing to the local file.
-        KeyError
-            If the response doesn't contain Content-Length header.
-        """
-        response = requests.get(
-            url,
-            stream=True,
-            timeout=5,
-            headers=eos_downloader.defaults.DEFAULT_REQUEST_HEADERS,
-        )
-        # This will break if the response doesn't contain content length
-        self.progress.update(task_id, total=int(response.headers["Content-Length"]))
-        with open(path, "wb") as dest_file:
-            self.progress.start_task(task_id)
-            for data in response.iter_content(chunk_size=block_size):
-                dest_file.write(data)
-                self.progress.update(task_id, advance=len(data))
-                if done_event.is_set():
-                    return True
-        # console.print(f"Downloaded {path}")
-        return False
-
-    def download(self, urls: Iterable[str], dest_dir: str) -> None:
-        """Download files from URLs concurrently to a destination directory.
-
-        This method downloads files from the provided URLs in parallel using a thread pool,
-        displaying progress for each download in the console.
-
-        Parameters
-        ----------
-        urls : Iterable[str]
-            An iterable of URLs to download files from.
-        dest_dir : str
-            The destination directory where files will be saved.
-
-        Returns
-        -------
-        None
-
-        Examples
-        --------
-        >>> downloader = DownloadProgressBar()
-        >>> urls = ["http://example.com/file1.txt", "http://example.com/file2.txt"]
-        >>> downloader.download(urls, "/path/to/destination")
-        """
-        with self.progress:
-            with ThreadPoolExecutor(max_workers=4) as pool:
-                futures = []
-                for url in urls:
-                    filename = url.split("/")[-1].split("?")[0]
-                    dest_path = os.path.join(dest_dir, filename)
-                    task_id = self.progress.add_task(
-                        "download", filename=filename, start=False
-                    )
-                    futures.append(pool.submit(self._copy_url, task_id, url, dest_path))
-
-                for future in futures:
-                    future.result()  # Wait for all downloads to complete
+    file_list: List[DownloadItem] = list(items)
+    if not file_list:
+        return
+    done_event = Event()
+    with sigint_guard(done_event), reporter:
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = [
+                pool.submit(_stream_to_file, item, reporter, done_event, block_size)
+                for item in file_list
+            ]
+            for future in futures:
+                future.result()  # Propagate exceptions and wait for completion.

--- a/eos_downloader/logics/download.py
+++ b/eos_downloader/logics/download.py
@@ -1,17 +1,14 @@
 # coding: utf-8 -*-
-"""ObjectDownloader class to manage file downloads with an option to use rich interface.
+"""SoftManager class to manage file downloads with a progress display.
 
-This class provides methods to download files from URLs with progress tracking using either
-tqdm or rich interface. It supports both raw downloads and enhanced visual feedback during
-the download process.
+This class downloads files from URLs with progress tracking rendered through the
+:mod:`eos_downloader.helpers` reporter layer, which selects a rich (terminal) or
+plain (CI / non-TTY) display automatically.
 
 Methods
 --------
-download_file(url: str, file_path: str, filename: str, rich_interface: bool = True) -> Union[None, str]
-    Downloads a file from the given URL to the specified path with optional rich interface.
-
-_download_file_raw(url: str, file_path: str) -> str
-    Static method that performs the actual file download with tqdm progress bar.
+download_file(url: str, file_path: str, filename: str, *, progress: ProgressMode = "auto") -> Union[None, str]
+    Downloads a file from the given URL to the specified path with a progress display.
 
 Attributes
 --------
@@ -19,12 +16,11 @@ None
 
 Example
 --------
-    >>> downloader = ObjectDownloader()
+    >>> downloader = SoftManager()
     >>> result = downloader.download_file(
     ...     url='http://example.com/file.zip',
     ...     file_path='/downloads',
     ...     filename='file.zip',
-    ...     rich_interface=True
     ... )
 """
 
@@ -32,18 +28,54 @@ import os
 import shutil
 import hashlib
 import subprocess
-from typing import Union, Literal, Dict, Optional
+import warnings
+from typing import Union, Literal, Dict, List, Optional
 from pathlib import Path
 
-import requests
-from tqdm import tqdm
 from loguru import logger
+from rich.console import Console
 
 import eos_downloader.models.types
 import eos_downloader.defaults
 import eos_downloader.helpers
 import eos_downloader.logics.arista_xml_server
 import eos_downloader.models.version
+from eos_downloader.helpers import (
+    DownloadItem,
+    download_files_concurrently,
+    resolve_reporter,
+)
+from eos_downloader.models.types import ProgressMode
+
+
+def _resolve_progress_mode(
+    progress: ProgressMode, rich_interface: Optional[bool]
+) -> ProgressMode:
+    """Resolve the effective progress mode, honouring the deprecated alias.
+
+    Parameters
+    ----------
+    progress : ProgressMode
+        Explicit progress mode ("auto", "rich", "plain", "none").
+    rich_interface : Optional[bool]
+        Deprecated alias. ``None`` means "not passed"; ``False`` maps to
+        ``"plain"`` and ``True`` maps to ``"auto"``. When provided, a
+        ``DeprecationWarning`` is emitted.
+
+    Returns
+    -------
+    ProgressMode
+        The effective progress mode.
+    """
+    if rich_interface is not None:
+        warnings.warn(
+            "The 'rich_interface' parameter is deprecated; use "
+            "progress='auto'|'rich'|'plain'|'none' instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return "plain" if rich_interface is False else "auto"
+    return progress
 
 
 class SoftManager:
@@ -63,7 +95,12 @@ class SoftManager:
     '/tmp/file.txt'
     """
 
-    def __init__(self, dry_run: bool = False, force_download: bool = False) -> None:
+    def __init__(
+        self,
+        dry_run: bool = False,
+        force_download: bool = False,
+        console: Optional[Console] = None,
+    ) -> None:
         """
         Initialize SoftManager.
 
@@ -73,6 +110,10 @@ class SoftManager:
             If True, simulate operations without executing them, by default False
         force_download : bool, optional
             If True, bypass cache and force download/import, by default False
+        console : Console, optional
+            Shared Rich console used to render the progress display. When omitted,
+            a default ``Console`` is created (its terminal detection then drives
+            ``progress="auto"``).
         """
         self.file: Dict[str, Union[str, None]] = {}
         self.file["name"] = None
@@ -80,6 +121,7 @@ class SoftManager:
         self.file["sha512sum"] = None
         self.dry_run = dry_run
         self.force_download = force_download
+        self.console = console if console is not None else Console()
         logger.info(
             f"SoftManager initialized{' in dry-run mode' if dry_run else ''}{' with force download' if force_download else ''}"
         )
@@ -150,44 +192,6 @@ class SoftManager:
         except (ValueError, FileNotFoundError, OSError) as e:
             logger.warning(f"Checksum validation failed: {e}")
             return False
-
-    @staticmethod
-    def _download_file_raw(url: str, file_path: str) -> str:
-        """Downloads a file from a URL and saves it to a local file.
-
-        Parameters
-        ----------
-        url : str
-            The URL of the file to download.
-        file_path : str
-            The local path where the file will be saved.
-
-        Returns
-        -------
-        str
-            The path to the downloaded file.
-
-        Notes
-        -----
-        - Uses requests library to stream download in chunks of 1024 bytes
-        - Shows download progress using tqdm progress bar
-        - Sets timeout of 5 seconds for initial connection
-        """
-
-        chunkSize = 1024
-        r = requests.get(url, stream=True, timeout=5)
-        with open(file_path, "wb") as f:
-            pbar = tqdm(
-                unit="B",
-                total=int(r.headers["Content-Length"]),
-                unit_scale=True,
-                unit_divisor=1024,
-            )
-            for chunk in r.iter_content(chunk_size=chunkSize):
-                if chunk:
-                    pbar.update(len(chunk))
-                f.write(chunk)
-        return file_path
 
     @staticmethod
     def _create_destination_folder(path: str) -> None:
@@ -330,7 +334,8 @@ class SoftManager:
         file_path: str,
         filename: str,
         *,
-        rich_interface: bool = True,
+        progress: ProgressMode = "auto",
+        rich_interface: Optional[bool] = None,
         force: bool = False,
     ) -> Union[None, str]:
         """
@@ -344,8 +349,12 @@ class SoftManager:
             The directory path where the file should be saved.
         filename : str
             The name to be given to the downloaded file.
+        progress : ProgressMode, optional
+            Progress rendering mode: ``"auto"`` (default, picks rich on a TTY and
+            plain otherwise), ``"rich"``, ``"plain"`` or ``"none"``.
         rich_interface : bool, optional
-            Whether to use rich progress bar interface. Defaults to True.
+            Deprecated. Use ``progress`` instead. ``False`` maps to
+            ``progress="plain"`` and ``True`` maps to ``progress="auto"``.
         force : bool, optional
             If True, download even if file exists locally. Defaults to False.
 
@@ -364,6 +373,7 @@ class SoftManager:
         ... )
         '/downloads/EOS-4.29.3M.swi'
         """
+        mode = _resolve_progress_mode(progress, rich_interface)
         full_path = Path(file_path) / filename
 
         # Check cache unless force flag is set
@@ -383,12 +393,10 @@ class SoftManager:
 
         # Proceed with download
         if url is not False:
-            if not rich_interface:
-                return self._download_file_raw(
-                    url=url, file_path=os.path.join(file_path, filename)
-                )
-            rich_downloader = eos_downloader.helpers.DownloadProgressBar()
-            rich_downloader.download(urls=[url], dest_dir=file_path)
+            reporter = resolve_reporter(
+                mode, self.console, title=f"Downloading {filename}"
+            )
+            download_files_concurrently([(url, str(full_path), filename)], reporter)
             return os.path.join(file_path, filename)
 
         logger.error(f"Cannot download file {file_path}")
@@ -398,7 +406,9 @@ class SoftManager:
         self,
         object_arista: eos_downloader.logics.arista_xml_server.AristaXmlObjects,
         file_path: str,
-        rich_interface: bool = True,
+        *,
+        progress: ProgressMode = "auto",
+        rich_interface: Optional[bool] = None,
     ) -> tuple[str, bool]:
         """
         Downloads files from Arista EOS server with caching support.
@@ -406,7 +416,8 @@ class SoftManager:
         Downloads the EOS image and optional md5/sha512 files based on the
         provided EOS XML object. Each file is downloaded to the specified path
         with appropriate filenames. Uses cache to skip already downloaded files
-        unless force_download is enabled.
+        unless force_download is enabled. The files of a single download are
+        fetched concurrently and rendered in one shared progress display.
 
         Parameters
         ----------
@@ -414,8 +425,12 @@ class SoftManager:
             Object containing EOS image and hash file URLs.
         file_path : str
             Directory path where files should be downloaded.
+        progress : ProgressMode, optional
+            Progress rendering mode: ``"auto"`` (default), ``"rich"``,
+            ``"plain"`` or ``"none"``.
         rich_interface : bool, optional
-            Whether to use rich console output. Defaults to True.
+            Deprecated. Use ``progress`` instead. ``False`` maps to
+            ``progress="plain"`` and ``True`` maps to ``progress="auto"``.
 
         Returns
         -------
@@ -440,6 +455,8 @@ class SoftManager:
         >>> cached  # Will be False
         False
         """
+        mode = _resolve_progress_mode(progress, rich_interface)
+
         logger.info(
             f"Processing files for {object_arista.version} "
             f"(force_download={self.force_download})"
@@ -457,6 +474,8 @@ class SoftManager:
 
         # Track if all files were retrieved from cache
         all_files_cached = True
+        # Files that actually need downloading, streamed together under one display.
+        to_download: List[DownloadItem] = []
 
         for file_type, url in sorted(object_arista.urls.items(), reverse=True):
             logger.debug(f"Processing {file_type} from {url}")
@@ -472,27 +491,12 @@ class SoftManager:
             if filename is None:
                 logger.error(f"Filename not found for {file_type}")
                 raise ValueError(f"Filename not found for {file_type}")
-            if not self.dry_run:
-                # Check if file is already cached before download
-                full_path = Path(file_path) / filename
-                file_was_cached = full_path.exists() and not self.force_download
 
-                # download_file will check cache automatically
-                # unless self.force_download is True
-                self.download_file(
-                    url,
-                    file_path,
-                    filename,
-                    rich_interface=rich_interface,
-                    force=self.force_download,
-                )
+            full_path = Path(file_path) / filename
+            file_was_cached = full_path.exists() and not self.force_download
 
-                # Update cache tracking
-                if not file_was_cached:
-                    all_files_cached = False
-            else:
-                full_path = Path(file_path) / filename
-                if full_path.exists() and not self.force_download:
+            if self.dry_run:
+                if file_was_cached:
                     logger.info(f"[DRY-RUN] Would use cached file: {filename}")
                 else:
                     logger.info(
@@ -500,6 +504,19 @@ class SoftManager:
                         f"for version {object_arista.version}"
                     )
                     all_files_cached = False
+                continue
+
+            if file_was_cached:
+                logger.info(f"Using cached file: {full_path}")
+            else:
+                all_files_cached = False
+                to_download.append((url, str(full_path), filename))
+
+        if to_download:
+            reporter = resolve_reporter(
+                mode, self.console, title=f"Downloading {object_arista.version}"
+            )
+            download_files_concurrently(to_download, reporter)
 
         return file_path, all_files_cached
 
@@ -669,6 +686,7 @@ class SoftManager:
         self,
         object_arista: eos_downloader.logics.arista_xml_server.EosXmlObject,
         noztp: bool = False,
+        progress: ProgressMode = "auto",
     ) -> None:
         """
         Provisions EVE-NG with the specified Arista EOS object.
@@ -679,6 +697,9 @@ class SoftManager:
             The Arista EOS object containing version, filename, and URLs.
         noztp : bool, optional
             If True, disables ZTP (Zero Touch Provisioning). Defaults to False.
+        progress : ProgressMode, optional
+            Progress rendering mode: ``"auto"`` (default), ``"rich"``,
+            ``"plain"`` or ``"none"``.
 
         Raises
         ------
@@ -741,7 +762,7 @@ class SoftManager:
             logger.debug(
                 f"downloading file {filename} for version {object_arista.version}"
             )
-            self.download_file(url, file_path, filename, rich_interface=True)
+            self.download_file(url, file_path, filename, progress=progress)
 
         # Convert to QCOW2 format
         if eos_filename is None:

--- a/eos_downloader/models/types.py
+++ b/eos_downloader/models/types.py
@@ -13,6 +13,8 @@ AristaVersions : Union
     Union type for supported SemVer object types. Can be either EosVersion or CvpVersion.
 ReleaseType : Literal
     Literal type for release types. Can be either "M" (maintenance) or "F" (feature).
+ProgressMode : Literal
+    Literal type for download progress rendering modes: "auto", "rich", "plain" or "none".
 
 Examples
 --------
@@ -47,3 +49,6 @@ AristaVersions = Union[
 
 # List of supported release codes
 ReleaseType = Literal["M", "F"]
+
+# Download progress rendering modes
+ProgressMode = Literal["auto", "rich", "plain", "none"]

--- a/openspec/changes/archive/2026-07-19-enhance-download-progress/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-19-enhance-download-progress/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/archive/2026-07-19-enhance-download-progress/design.md
+++ b/openspec/changes/archive/2026-07-19-enhance-download-progress/design.md
@@ -1,0 +1,161 @@
+## Context
+
+Download progress today is produced two different ways:
+
+- `SoftManager.download_file(rich_interface=True)` (always true from the CLI)
+  creates a new `eos_downloader.helpers.DownloadProgressBar` per file. Each
+  instance owns its own Rich `Progress` and enters/exits its own `with` block,
+  so a multi-file download (image + `sha512`, sometimes `md5`) shows several
+  progress blocks appearing and disappearing in sequence.
+- `SoftManager._download_file_raw` renders via `tqdm`. This path is only reached
+  when `rich_interface=False`, which never happens from the CLI — it is dead
+  code, and `tqdm` remains a declared dependency.
+
+Additional friction: `helpers/__init__.py` builds its own `Console`, separate
+from the CLI's `console_configuration()`; `DownloadProgressBar.download()` was
+written for a `ThreadPoolExecutor` with 4 workers but is always called with a
+single-URL list, so the concurrency is inert; and the module installs a global
+`signal.signal(SIGINT, ...)` at import time.
+
+Constraints:
+- **CI / non-TTY must keep working** and must not emit ANSI control sequences.
+- The library API (`SoftManager`) is public — breaking callers outright is not
+  acceptable without a migration path.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A single, polished grouped display per download (one Panel, one bar per file,
+  ETA, per-file state, aggregated Total bar) in a terminal.
+- Clean, ANSI-free `loguru` output in non-TTY / CI.
+- One shared `Console` between CLI and downloader.
+- Real inter-file concurrency using the existing thread pool.
+- Remove `tqdm` and the dead raw path; remove the import-time signal side effect.
+- Replace `rich_interface` with a `progress` mode while preserving the old
+  parameter as a deprecated alias.
+
+**Non-Goals:**
+- Intra-file segmented / multi-connection (HTTP Range) download — the actual
+  single-file speed-up. Separate follow-up change.
+- Cross-download concurrency (downloading several versions at once).
+- Changing checksum, caching, docker-import, or EVE-NG provisioning logic beyond
+  the call-site parameter rename.
+
+## Decisions
+
+### 1. A `DownloadReporter` interface with two implementations
+
+Introduce a small interface (e.g. an abstract base or `Protocol`) exposing the
+lifecycle the download loop needs, roughly:
+
+```
+class DownloadReporter:
+    def __enter__/__exit__            # start/stop the live display
+    def add_file(name, total) -> id   # register a file
+    def advance(id, n_bytes)          # progress
+    def complete(id)                  # mark a file done
+```
+
+- `RichReporter` wraps one shared `rich.progress.Progress` (with `TextColumn`,
+  `BarColumn`, `TaskProgressColumn`/percentage, `TransferSpeedColumn`,
+  `DownloadColumn`, `TimeRemainingColumn`, and a `SpinnerColumn`) plus a separate
+  "Total" task, rendered inside a titled `Panel` via `Live`.
+- `PlainReporter` implements the same methods but emits `loguru` lines: one at
+  `add_file` (name + total size), milestone lines from `advance` (e.g. every
+  25%), and one at `complete` (size + duration + average speed). No `Live`, no
+  ANSI.
+
+Rationale: one seam lets the download loop stay identical across TTY and CI, and
+keeps Rich objects out of `SoftManager`'s core logic. Alternative — branching on
+`is_terminal` inside `download_file` with two inline code paths — was rejected as
+the exact duplication that made the current code inconsistent.
+
+### 2. One shared `Progress` per `downloads()` call, opened around the loop
+
+`SoftManager.downloads()` creates one reporter, enters it once, and passes it
+into each `download_file()` invocation (which registers a file and streams into
+it) instead of each `download_file()` creating its own display. `download_file()`
+called standalone (library use) still works by creating a one-file reporter
+internally when none is supplied.
+
+Rationale: removes the flicker (the visible core defect) and is the natural home
+for the Total bar. Alternative — keeping per-file `Progress` but stacking them in
+a `Group` — still tears down/recreates and complicates the Total aggregation.
+
+### 3. Reporter selection via `progress` mode + shared console
+
+`progress: Literal["auto","rich","plain","none"] = "auto"`. `"auto"` picks by
+`console.is_terminal`; `"rich"`/`"plain"` force; `"none"` uses a no-op reporter.
+The `Console` is created once (in `cli/utils.py`) and threaded down into
+`SoftManager`, replacing the module-global console in `helpers`.
+
+### 4. `rich_interface` kept as a deprecated alias
+
+Signatures accept both. Resolution:
+
+```
+if rich_interface is not None:
+    warnings.warn(..., DeprecationWarning, stacklevel=2)
+    progress = "plain" if rich_interface is False else "auto"
+```
+
+`rich_interface` defaults to `None` (sentinel) so we can distinguish "not passed"
+from an explicit bool. Rationale: zero breakage for existing library callers,
+clean new surface, removable at the next major.
+
+### 5. Signal handling scoped to a download
+
+Move `signal.signal(SIGINT, handler)` out of module scope. The `RichReporter`
+(and the plain path) install/restore the handler within their `__enter__` /
+`__exit__` using `signal.getsignal` to save and restore the previous handler, so
+importing the module has no global effect. A threading `Event` still signals the
+worker threads to stop.
+
+Rationale: import side effects are surprising and hostile to library embedding
+and tests. Trade-off: signal handlers only work in the main thread — acceptable
+since the reporter is entered from the main thread.
+
+### 6. Remove `tqdm`
+
+Delete `_download_file_raw` and the `tqdm` import; drop `tqdm` from
+`pyproject.toml`. The former `rich_interface=False` behavior is superseded by
+`progress="plain"`.
+
+## Risks / Trade-offs
+
+- **Public API change on `SoftManager`** → Mitigated by the deprecated
+  `rich_interface` alias with a `DeprecationWarning`; documented in the proposal
+  as a soft-breaking change.
+- **Rich `Progress`/`Live` may still emit control chars if `is_terminal`
+  detection is wrong (e.g. odd CI TERM)** → `"auto"` relies on Rich's own
+  detection, and CI can force `progress="plain"` (or `--no-progress`); the plain
+  path is guaranteed ANSI-free.
+- **Thread-safety of shared `Progress` updates** → Rich `Progress.update` is
+  thread-safe; each worker owns a distinct task id, so concurrent `advance`
+  calls do not contend on the same task.
+- **Concurrency changes log/interleave ordering** → Per-file rows isolate output
+  in TTY; in plain mode, log lines carry the filename so interleaving stays
+  readable.
+- **Content-Length missing** → current code assumes the header exists; keep a
+  guard so an unknown total renders an indeterminate bar / a start line without a
+  total rather than crashing.
+
+## Migration Plan
+
+1. Add the reporter layer in `helpers/` without removing the old class yet.
+2. Thread the shared `Console` and `progress` param through `SoftManager` and CLI
+   call sites; add the `rich_interface` alias shim.
+3. Switch `downloads()` to the single-reporter loop with concurrency.
+4. Remove `_download_file_raw`, the old `DownloadProgressBar` internals, the
+   module-level signal call, and the `tqdm` dependency.
+5. Update tests/docs.
+
+Rollback: revert the branch; no persisted state or data migration is involved.
+
+## Resolved Decisions
+
+- **CLI `--no-progress` flag**: added on the download commands, mapping to
+  `progress="none"`. Auto-detection stays the default; the flag gives CI an
+  explicit, discoverable override.
+- **`PlainReporter` milestones**: one progress line at each 10% step
+  (10%, 20%, … 90%), plus the start and completion lines.

--- a/openspec/changes/archive/2026-07-19-enhance-download-progress/proposal.md
+++ b/openspec/changes/archive/2026-07-19-enhance-download-progress/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+The CLI download progress display is built by instantiating a fresh
+`DownloadProgressBar` (Rich `Progress`) for every single file of a download.
+Because an EOS/CVP download is made of several files (the image plus its
+`sha512`/`md5` hashes), the user sees a separate progress block appear and
+disappear for each file instead of one coherent, grouped display — it flickers
+and looks unpolished. On top of that, a second, dead progress path built on
+`tqdm` still ships as a dependency, the downloader owns its own `Console`
+separate from the rest of the CLI, and the concurrency machinery that already
+exists (`ThreadPoolExecutor`) is never actually used because each call downloads
+a single URL. There is also an import-time side effect installing a global
+`SIGINT` handler.
+
+## What Changes
+
+- Introduce a `DownloadReporter` abstraction with two implementations selected
+  automatically from `console.is_terminal`:
+  - `RichReporter` (TTY): a single grouped, "dressed-up" display — one Rich
+    `Progress` inside a titled `Panel`, one bar per file with ETA and a
+    per-file spinner/done state, plus an aggregated **Total** bar.
+  - `PlainReporter` (non-TTY / CI): clean `loguru` log lines (start, periodic
+    percentage milestones, done with size/duration/speed) and **no ANSI codes**.
+    CI / non-TTY compatibility is a hard requirement.
+- Use **one** shared `Progress` instance for all files of a single download
+  instead of one instance per file (removes the flicker).
+- Share **one** `Console` between the downloader and `cli/utils.py`.
+- Reactivate **inter-file parallelism** using the already-present
+  `ThreadPoolExecutor` so the image and its hash files download concurrently
+  under the same grouped display.
+- **BREAKING (soft)** Replace the `rich_interface: bool` parameter of
+  `SoftManager.download_file()` / `SoftManager.downloads()` with
+  `progress: "auto" | "rich" | "plain" | "none"`. `rich_interface` is kept as a
+  **deprecated alias** (`False` → `"plain"`, `True` → `"auto"`) that emits a
+  `DeprecationWarning`, so existing library callers are not broken.
+- Remove the dead `tqdm` code path (`SoftManager._download_file_raw`) and drop
+  the `tqdm` dependency from `pyproject.toml`.
+- Move the module-level `signal.signal(SIGINT, ...)` call out of import time to
+  remove the import side effect; interruption handling is scoped to an active
+  download.
+
+Explicitly **out of scope**: intra-file segmented / multi-connection download
+(HTTP Range) — the change that would actually speed up a single large file. It
+depends on server support and needs its own error-recovery design, and will be
+proposed as a separate follow-up change.
+
+## Capabilities
+
+### New Capabilities
+- `download-progress`: How download progress is reported to the user — the
+  TTY vs non-TTY reporter selection, the grouped multi-file display contract,
+  parallelism of a download's files, and the `progress` parameter (with the
+  deprecated `rich_interface` alias).
+
+### Modified Capabilities
+<!-- None: there is no existing spec describing download progress today. -->
+
+## Impact
+
+- **Code**
+  - `eos_downloader/helpers/__init__.py` — `DownloadProgressBar` reworked into
+    the reporter layer; module-level `SIGINT` side effect removed.
+  - `eos_downloader/logics/download.py` — `SoftManager.download_file()` /
+    `downloads()` signatures (`progress=` + `rich_interface` alias); one shared
+    reporter per `downloads()` call; `_download_file_raw` removed.
+  - `eos_downloader/cli/utils.py` and `eos_downloader/cli/get/` — pass the shared
+    `Console` into the downloader; call sites updated for the new `progress=`
+    parameter.
+- **Public API**: `SoftManager.download_file` / `downloads` signature change,
+  softened by the deprecated `rich_interface` alias.
+- **Dependencies**: `tqdm` removed from `pyproject.toml`.
+- **Behavior**: download output is now a single grouped display (TTY) or clean
+  log lines (CI); files of one download are fetched concurrently.

--- a/openspec/changes/archive/2026-07-19-enhance-download-progress/specs/download-progress/spec.md
+++ b/openspec/changes/archive/2026-07-19-enhance-download-progress/specs/download-progress/spec.md
@@ -1,0 +1,127 @@
+## ADDED Requirements
+
+### Requirement: Automatic reporter selection by terminal capability
+
+The system SHALL report download progress through a `DownloadReporter`
+abstraction with two implementations, and SHALL select one automatically based
+on whether the shared `Console` is attached to an interactive terminal.
+
+#### Scenario: Interactive terminal selects the rich reporter
+- **WHEN** a download starts and the shared `Console.is_terminal` is `True`
+- **THEN** the system uses the `RichReporter` (animated grouped display)
+
+#### Scenario: Non-interactive output selects the plain reporter
+- **WHEN** a download starts and the shared `Console.is_terminal` is `False`
+  (piped output, CI, redirected file)
+- **THEN** the system uses the `PlainReporter`
+- **AND** no ANSI escape sequences are emitted to the output stream
+
+### Requirement: Grouped single-progress display for a download
+
+The system SHALL render all files of a single download (image plus its hash
+files) within one shared Rich `Progress` instance, so the display does not
+create and tear down a separate progress block per file.
+
+#### Scenario: Multi-file download renders as one grouped block
+- **WHEN** a download of an image and its `sha512` file is rendered in a terminal
+- **THEN** both files appear as bars within a single titled `Panel`
+- **AND** an aggregated **Total** bar reflects combined progress across the files
+- **AND** the display is not torn down and recreated between files
+
+#### Scenario: Per-file completion state
+- **WHEN** an individual file within the grouped display finishes
+- **THEN** its row shows a completed state while the other rows keep updating
+
+### Requirement: Concurrent download of a download's files
+
+The system SHALL download the files that make up a single download (image and
+hash files) concurrently using a thread pool, updating their respective bars in
+the shared display.
+
+#### Scenario: Image and hash download concurrently
+- **WHEN** a download contains an image file and one or more hash files
+- **THEN** the files are fetched concurrently rather than strictly sequentially
+- **AND** each file's progress updates its own row in the shared display
+- **AND** the call returns only after all files have completed
+
+### Requirement: Non-TTY progress is reported as log lines
+
+In non-interactive mode the system SHALL report progress as `loguru` log lines
+rather than an animated bar, covering start, intermediate progress, and
+completion.
+
+#### Scenario: Plain reporter emits lifecycle log lines
+- **WHEN** a file is downloaded under the `PlainReporter`
+- **THEN** a start line records the filename and total size
+- **AND** a progress line is emitted at each 10% milestone (10%, 20%, … 90%)
+- **AND** a completion line records the transferred size and duration
+
+### Requirement: Progress mode parameter
+
+`SoftManager.download_file()` and `SoftManager.downloads()` SHALL accept a
+`progress` parameter with values `"auto"`, `"rich"`, `"plain"`, or `"none"`
+controlling reporter selection, defaulting to `"auto"`.
+
+#### Scenario: Auto defers to terminal detection
+- **WHEN** `progress="auto"` (the default)
+- **THEN** the reporter is chosen from `Console.is_terminal`
+
+#### Scenario: Explicit rich or plain overrides detection
+- **WHEN** `progress="rich"` or `progress="plain"` is passed
+- **THEN** the corresponding reporter is used regardless of terminal detection
+
+#### Scenario: None disables progress rendering
+- **WHEN** `progress="none"` is passed
+- **THEN** no progress display is rendered while the download still proceeds
+
+#### Scenario: CLI `--no-progress` flag disables the display
+- **WHEN** a download command is invoked with `--no-progress`
+- **THEN** the download runs with `progress="none"` and renders no progress display
+
+### Requirement: Deprecated `rich_interface` alias
+
+The system SHALL keep the `rich_interface` boolean parameter as a deprecated
+alias for `progress` so existing library callers are not broken, and SHALL emit
+a `DeprecationWarning` when it is used.
+
+#### Scenario: rich_interface=False maps to plain
+- **WHEN** a caller passes `rich_interface=False`
+- **THEN** the effective mode is `progress="plain"`
+- **AND** a `DeprecationWarning` is emitted
+
+#### Scenario: rich_interface=True maps to auto
+- **WHEN** a caller passes `rich_interface=True`
+- **THEN** the effective mode is `progress="auto"`
+- **AND** a `DeprecationWarning` is emitted
+
+### Requirement: Single shared console
+
+The downloader SHALL render through the same `Console` instance used by the rest
+of the CLI rather than constructing its own.
+
+#### Scenario: Downloader uses the CLI console
+- **WHEN** a download renders progress from within the CLI
+- **THEN** it uses the `Console` provided by the CLI layer
+
+### Requirement: No import-time signal side effect
+
+Importing the download helpers module SHALL NOT install a process-wide signal
+handler; interrupt handling SHALL be scoped to an active download.
+
+#### Scenario: Import does not alter SIGINT handling
+- **WHEN** the download helpers module is imported
+- **THEN** the process `SIGINT` handler is not replaced as a side effect of import
+
+#### Scenario: Interrupt during an active download is handled
+- **WHEN** the user interrupts (Ctrl+C) while a download is in progress
+- **THEN** the download terminates gracefully
+
+### Requirement: Removal of the tqdm progress path
+
+The system SHALL NOT depend on `tqdm`; the legacy `tqdm`-based raw download path
+is removed.
+
+#### Scenario: tqdm is not a dependency
+- **WHEN** the project dependencies are inspected
+- **THEN** `tqdm` is not listed as a runtime dependency
+- **AND** no code path renders progress via `tqdm`

--- a/openspec/changes/archive/2026-07-19-enhance-download-progress/tasks.md
+++ b/openspec/changes/archive/2026-07-19-enhance-download-progress/tasks.md
@@ -1,0 +1,42 @@
+## 1. Reporter layer
+
+- [x] 1.1 Add a `DownloadReporter` interface (ABC or `Protocol`) with `add_file(name, total) -> id`, `advance(id, n)`, `complete(id)`, and context-manager start/stop, in `eos_downloader/helpers/`
+- [x] 1.2 Implement `RichReporter`: one shared `rich.progress.Progress` with spinner, filename, bar, percentage, transfer speed, download size, and time-remaining columns, rendered in a titled `Panel`, plus an aggregated **Total** task
+- [x] 1.3 Implement `PlainReporter`: `loguru` lifecycle lines (start with size, a progress line at each 10% milestone, completion with size/duration/speed), no ANSI, no `Live`
+- [x] 1.4 Implement a no-op reporter for `progress="none"`
+- [x] 1.5 Add a factory that resolves `progress` mode + shared `Console` into the concrete reporter (`"auto"` → `console.is_terminal`)
+- [x] 1.6 Handle missing `Content-Length` gracefully (indeterminate bar / start line without total)
+
+## 2. Signal handling
+
+- [x] 2.1 Remove the module-level `signal.signal(SIGINT, ...)` side effect from `helpers/__init__.py`
+- [x] 2.2 Install/restore the SIGINT handler inside the reporter's start/stop using `signal.getsignal`; keep a threading `Event` to stop worker threads
+
+## 3. Shared console
+
+- [x] 3.1 Make `cli/utils.py` own the single `Console` and expose it to the download layer
+- [x] 3.2 Remove the module-global `Console` in `helpers/__init__.py`; thread the shared console down into `SoftManager`
+
+## 4. SoftManager integration
+
+- [x] 4.1 Add `progress: Literal["auto","rich","plain","none"] = "auto"` to `SoftManager.download_file()` and `downloads()`
+- [x] 4.2 Add `rich_interface` deprecated alias (sentinel default `None`; `False`→`"plain"`, `True`→`"auto"`) emitting `DeprecationWarning`
+- [x] 4.3 Rework `downloads()` to create one reporter, enter it once, and download the image + hash files concurrently via the existing `ThreadPoolExecutor`, each updating its own bar
+- [x] 4.4 Make `download_file()` register a file on a supplied reporter, or create a one-file reporter when called standalone
+- [x] 4.5 Remove `SoftManager._download_file_raw` and the old `DownloadProgressBar` internals
+
+## 5. Dependency & call sites
+
+- [x] 5.1 Remove `tqdm` from `pyproject.toml` and delete its imports
+- [x] 5.2 Update all CLI call sites (`cli/get/commands.py`, `cli/get/utils.py`) to pass the shared console and `progress=` instead of `rich_interface=True`
+- [x] 5.3 Add a CLI `--no-progress` flag that maps to `progress="none"` (available on the download commands)
+
+## 6. Tests & docs
+
+- [x] 6.1 Unit test reporter selection: `auto` with `is_terminal` True/False, explicit `rich`/`plain`/`none`
+- [x] 6.2 Unit test `rich_interface` alias mapping emits `DeprecationWarning` and resolves to the right mode
+- [x] 6.3 Test that `PlainReporter` output contains no ANSI escape sequences
+- [x] 6.4 Test that importing the helpers module does not replace the process SIGINT handler
+- [x] 6.5 Test concurrent multi-file download completes and updates one shared display
+- [x] 6.6 Update docs/docstrings for the new `progress` parameter and the `rich_interface` deprecation
+- [x] 6.7 Run `make check` (lint + type + test) and fix findings

--- a/openspec/specs/download-progress/spec.md
+++ b/openspec/specs/download-progress/spec.md
@@ -1,0 +1,130 @@
+# download-progress Specification
+
+## Purpose
+Define how download progress is reported to the user: the automatic selection between a rich (interactive terminal) and a plain (non-TTY / CI) reporter, the grouped single-display contract for a download's files, concurrent fetching of those files, and the `progress` parameter (with the deprecated `rich_interface` alias).
+## Requirements
+### Requirement: Automatic reporter selection by terminal capability
+
+The system SHALL report download progress through a `DownloadReporter`
+abstraction with two implementations, and SHALL select one automatically based
+on whether the shared `Console` is attached to an interactive terminal.
+
+#### Scenario: Interactive terminal selects the rich reporter
+- **WHEN** a download starts and the shared `Console.is_terminal` is `True`
+- **THEN** the system uses the `RichReporter` (animated grouped display)
+
+#### Scenario: Non-interactive output selects the plain reporter
+- **WHEN** a download starts and the shared `Console.is_terminal` is `False`
+  (piped output, CI, redirected file)
+- **THEN** the system uses the `PlainReporter`
+- **AND** no ANSI escape sequences are emitted to the output stream
+
+### Requirement: Grouped single-progress display for a download
+
+The system SHALL render all files of a single download (image plus its hash
+files) within one shared Rich `Progress` instance, so the display does not
+create and tear down a separate progress block per file.
+
+#### Scenario: Multi-file download renders as one grouped block
+- **WHEN** a download of an image and its `sha512` file is rendered in a terminal
+- **THEN** both files appear as bars within a single titled `Panel`
+- **AND** an aggregated **Total** bar reflects combined progress across the files
+- **AND** the display is not torn down and recreated between files
+
+#### Scenario: Per-file completion state
+- **WHEN** an individual file within the grouped display finishes
+- **THEN** its row shows a completed state while the other rows keep updating
+
+### Requirement: Concurrent download of a download's files
+
+The system SHALL download the files that make up a single download (image and
+hash files) concurrently using a thread pool, updating their respective bars in
+the shared display.
+
+#### Scenario: Image and hash download concurrently
+- **WHEN** a download contains an image file and one or more hash files
+- **THEN** the files are fetched concurrently rather than strictly sequentially
+- **AND** each file's progress updates its own row in the shared display
+- **AND** the call returns only after all files have completed
+
+### Requirement: Non-TTY progress is reported as log lines
+
+In non-interactive mode the system SHALL report progress as `loguru` log lines
+rather than an animated bar, covering start, intermediate progress, and
+completion.
+
+#### Scenario: Plain reporter emits lifecycle log lines
+- **WHEN** a file is downloaded under the `PlainReporter`
+- **THEN** a start line records the filename and total size
+- **AND** a progress line is emitted at each 10% milestone (10%, 20%, … 90%)
+- **AND** a completion line records the transferred size and duration
+
+### Requirement: Progress mode parameter
+
+`SoftManager.download_file()` and `SoftManager.downloads()` SHALL accept a
+`progress` parameter with values `"auto"`, `"rich"`, `"plain"`, or `"none"`
+controlling reporter selection, defaulting to `"auto"`.
+
+#### Scenario: Auto defers to terminal detection
+- **WHEN** `progress="auto"` (the default)
+- **THEN** the reporter is chosen from `Console.is_terminal`
+
+#### Scenario: Explicit rich or plain overrides detection
+- **WHEN** `progress="rich"` or `progress="plain"` is passed
+- **THEN** the corresponding reporter is used regardless of terminal detection
+
+#### Scenario: None disables progress rendering
+- **WHEN** `progress="none"` is passed
+- **THEN** no progress display is rendered while the download still proceeds
+
+#### Scenario: CLI `--no-progress` flag disables the display
+- **WHEN** a download command is invoked with `--no-progress`
+- **THEN** the download runs with `progress="none"` and renders no progress display
+
+### Requirement: Deprecated `rich_interface` alias
+
+The system SHALL keep the `rich_interface` boolean parameter as a deprecated
+alias for `progress` so existing library callers are not broken, and SHALL emit
+a `DeprecationWarning` when it is used.
+
+#### Scenario: rich_interface=False maps to plain
+- **WHEN** a caller passes `rich_interface=False`
+- **THEN** the effective mode is `progress="plain"`
+- **AND** a `DeprecationWarning` is emitted
+
+#### Scenario: rich_interface=True maps to auto
+- **WHEN** a caller passes `rich_interface=True`
+- **THEN** the effective mode is `progress="auto"`
+- **AND** a `DeprecationWarning` is emitted
+
+### Requirement: Single shared console
+
+The downloader SHALL render through the same `Console` instance used by the rest
+of the CLI rather than constructing its own.
+
+#### Scenario: Downloader uses the CLI console
+- **WHEN** a download renders progress from within the CLI
+- **THEN** it uses the `Console` provided by the CLI layer
+
+### Requirement: No import-time signal side effect
+
+Importing the download helpers module SHALL NOT install a process-wide signal
+handler; interrupt handling SHALL be scoped to an active download.
+
+#### Scenario: Import does not alter SIGINT handling
+- **WHEN** the download helpers module is imported
+- **THEN** the process `SIGINT` handler is not replaced as a side effect of import
+
+#### Scenario: Interrupt during an active download is handled
+- **WHEN** the user interrupts (Ctrl+C) while a download is in progress
+- **THEN** the download terminates gracefully
+
+### Requirement: Removal of the tqdm progress path
+
+The system SHALL NOT depend on `tqdm`; the legacy `tqdm`-based raw download path
+is removed.
+
+#### Scenario: tqdm is not a dependency
+- **WHEN** the project dependencies are inspected
+- **THEN** `tqdm` is not listed as a runtime dependency
+- **AND** no code path renders progress via `tqdm`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
   "requests>=2.20.0",
   "requests-toolbelt",
   "scp",
-  "tqdm",
   "loguru",
   "rich>=13.5.2",
   "cvprac>=1.0.7",

--- a/tests/unit/cli/test_get_commands.py
+++ b/tests/unit/cli/test_get_commands.py
@@ -20,7 +20,6 @@ from typer.testing import CliRunner
 
 from eos_downloader.cli.cli import app
 
-
 # Fixtures
 
 
@@ -134,8 +133,8 @@ class TestEosCommand:
         # Execute
         with patch("eos_downloader.cli.get.commands.download_files"):
             result = runner.invoke(
-            app,
-            ["get", "eos", "--latest"],
+                app,
+                ["get", "eos", "--latest"],
                 obj=mock_context,
             )
 
@@ -170,8 +169,8 @@ class TestEosCommand:
         # Execute
         with patch("eos_downloader.cli.get.commands.download_files"):
             result = runner.invoke(
-            app,
-            ["get", "eos", "--latest", "--branch", "4.29"],
+                app,
+                ["get", "eos", "--latest", "--branch", "4.29"],
                 obj=mock_context,
             )
 
@@ -245,8 +244,10 @@ class TestEosCommand:
         # Execute
         with patch("eos_downloader.cli.get.commands.download_files"):
             result = runner.invoke(
-            app,
-            ["get", "eos", 
+                app,
+                [
+                    "get",
+                    "eos",
                     "--version",
                     "4.29.3M",
                     "--import-docker",
@@ -287,8 +288,8 @@ class TestEosCommand:
         # Execute
         with patch("eos_downloader.cli.get.commands.SoftManager"):
             result = runner.invoke(
-            app,
-            ["get", "eos", "--version", "4.29.3M", "--skip-download"],
+                app,
+                ["get", "eos", "--version", "4.29.3M", "--skip-download"],
                 obj=mock_context,
             )
 
@@ -321,14 +322,16 @@ class TestEosCommand:
         with patch("eos_downloader.cli.get.commands.SoftManager") as mock_sm:
             with patch("eos_downloader.cli.get.commands.download_files"):
                 result = runner.invoke(
-            app,
-            ["get", "eos", "--version", "4.29.3M", "--dry-run"],
+                    app,
+                    ["get", "eos", "--version", "4.29.3M", "--dry-run"],
                     obj=mock_context,
                 )
 
         # Assert
         assert result.exit_code == 0
-        mock_sm.assert_called_once_with(dry_run=True, force_download=False)
+        mock_sm.assert_called_once_with(
+            dry_run=True, force_download=False, console=mock_console
+        )
 
     @patch("eos_downloader.cli.get.commands.initialize")
     @patch("eos_downloader.cli.get.commands.search_version")
@@ -352,12 +355,17 @@ class TestEosCommand:
 
         with patch("eos_downloader.cli.get.commands.download_files"):
             result = runner.invoke(
-            app,
-            ["get", "eos", 
-                    "--version", "4.29.3M",
+                app,
+                [
+                    "get",
+                    "eos",
+                    "--version",
+                    "4.29.3M",
                     "--import-docker",
-                    "--docker-name", "arista/ceos",
-                    "--docker-tag", "4.29.3M",
+                    "--docker-name",
+                    "arista/ceos",
+                    "--docker-tag",
+                    "4.29.3M",
                     "--dry-run",
                 ],
                 obj=mock_context,
@@ -698,7 +706,9 @@ class TestCvpCommand:
 
         # Assert
         assert result.exit_code == 0
-        mock_soft_manager.assert_called_once_with(dry_run=True, force_download=False)
+        mock_soft_manager.assert_called_once_with(
+            dry_run=True, force_download=False, console=mock_console
+        )
 
     @patch("eos_downloader.cli.get.commands.initialize")
     @patch("eos_downloader.cli.get.commands.AristaXmlQuerier")
@@ -825,7 +835,9 @@ class TestPathCommand:
         # Execute
         result = runner.invoke(
             app,
-            ["get", "path", 
+            [
+                "get",
+                "path",
                 "--source",
                 "/path/to/EOS-4.29.3M.swi",
                 "--output",
@@ -1069,7 +1081,9 @@ class TestPathCommand:
         # Execute
         result = runner.invoke(
             app,
-            ["get", "path", 
+            [
+                "get",
+                "path",
                 "--source",
                 "/path/to/cEOS.tar",
                 "--import-docker",
@@ -1115,7 +1129,9 @@ class TestPathCommand:
         # Execute
         result = runner.invoke(
             app,
-            ["get", "path", 
+            [
+                "get",
+                "path",
                 "--source",
                 "/path/to/cEOS.tar",
                 "--import-docker",
@@ -1157,7 +1173,9 @@ class TestPathCommand:
         # Execute
         result = runner.invoke(
             app,
-            ["get", "path", 
+            [
+                "get",
+                "path",
                 "--source",
                 "/path/to/cEOS.tar",
                 "--import-docker",
@@ -1257,7 +1275,14 @@ class TestEosContainerlabCommand:
 
         result = runner.invoke(
             app,
-            ["get", "eos", "--containerlab-topology", str(topo_file), "--version", "4.29.3M"],
+            [
+                "get",
+                "eos",
+                "--containerlab-topology",
+                str(topo_file),
+                "--version",
+                "4.29.3M",
+            ],
             obj=mock_context,
         )
 
@@ -1306,7 +1331,14 @@ class TestEosContainerlabCommand:
 
         result = runner.invoke(
             app,
-            ["get", "eos", "--containerlab-topology", str(topo_file), "--branch", "4.29"],
+            [
+                "get",
+                "eos",
+                "--containerlab-topology",
+                str(topo_file),
+                "--branch",
+                "4.29",
+            ],
             obj=mock_context,
         )
 

--- a/tests/unit/cli/test_get_utils.py
+++ b/tests/unit/cli/test_get_utils.py
@@ -27,7 +27,6 @@ from eos_downloader.cli.get.utils import (
 )
 from eos_downloader.models.version import EosVersion
 
-
 # Fixtures
 
 
@@ -245,7 +244,7 @@ class TestDownloadFiles:
             cli=mock_cli,
             arista_dl_obj=mock_arista_dl_obj,
             output=str(output_path),
-            rich_interface=True,
+            progress="auto",
             debug=False,
             checksum_format="sha512sum",
         )
@@ -253,7 +252,7 @@ class TestDownloadFiles:
         # Assert - Function should execute without error
         # Check that cli.downloads() was called
         mock_cli.downloads.assert_called_once_with(
-            mock_arista_dl_obj, file_path=str(output_path), rich_interface=True
+            mock_arista_dl_obj, file_path=str(output_path), progress="auto"
         )
         mock_cli.checksum.assert_called_once_with("sha512sum")
 
@@ -274,7 +273,7 @@ class TestDownloadFiles:
             cli=mock_cli,
             arista_dl_obj=mock_arista_dl_obj,
             output=str(output_path),
-            rich_interface=True,
+            progress="auto",
             debug=False,
             checksum_format=checksum,
         )
@@ -298,7 +297,7 @@ class TestDownloadFiles:
             cli=mock_cli,
             arista_dl_obj=mock_arista_dl_obj,
             output=str(output_path),
-            rich_interface=True,
+            progress="auto",
             debug=False,
             checksum_format="sha512sum",
         )
@@ -330,7 +329,7 @@ class TestDownloadFiles:
                 cli=mock_cli,
                 arista_dl_obj=mock_arista_dl_obj,
                 output=str(tmp_path),
-                rich_interface=True,
+                progress="auto",
                 debug=False,
                 checksum_format="sha512sum",
             )
@@ -359,7 +358,7 @@ class TestDownloadFiles:
                 cli=mock_cli,
                 arista_dl_obj=mock_arista_dl_obj,
                 output=str(tmp_path),
-                rich_interface=True,
+                progress="auto",
                 debug=True,  # Enable debug mode
                 checksum_format="sha512sum",
             )
@@ -369,10 +368,10 @@ class TestDownloadFiles:
         # Assert that print_exception was called in debug mode
         mock_console.print_exception.assert_called_once_with(show_locals=True)
 
-    def test_download_files_no_rich_interface(
+    def test_download_files_plain_progress(
         self, mock_arista_dl_obj, mock_console, tmp_path
     ):
-        """Test download without Rich interface."""
+        """Test download with the plain (non-rich) progress mode."""
         # Setup
         mock_cli = MagicMock()
         # Mock downloads to return tuple (path, was_cached)
@@ -384,14 +383,14 @@ class TestDownloadFiles:
             cli=mock_cli,
             arista_dl_obj=mock_arista_dl_obj,
             output=str(tmp_path),
-            rich_interface=False,  # Disable Rich interface
+            progress="plain",  # Force plain (non-rich) interface
             debug=False,
             checksum_format="sha512sum",
         )
 
-        # Assert - cli.downloads should be called with rich_interface=False
+        # Assert - cli.downloads should be called with progress="plain"
         mock_cli.downloads.assert_called_once_with(
-            mock_arista_dl_obj, file_path=str(tmp_path), rich_interface=False
+            mock_arista_dl_obj, file_path=str(tmp_path), progress="plain"
         )
 
 
@@ -717,7 +716,7 @@ class TestDownloadFilesValueError:
                 cli=mock_cli,
                 arista_dl_obj=mock_dl_obj,
                 output="/tmp",
-                rich_interface=True,
+                progress="auto",
                 debug=False,
             )
 
@@ -749,7 +748,8 @@ class TestHandleDockerImportSuccess:
         assert result == 0
         # Verify "imported successfully" message
         success_msg = any(
-            "imported successfully" in str(call) for call in mock_console.print.call_args_list
+            "imported successfully" in str(call)
+            for call in mock_console.print.call_args_list
         )
         assert success_msg
 
@@ -907,7 +907,12 @@ class TestContainerlabTopologyEdgeCases:
     @patch("eos_downloader.cli.get.utils.EosXmlObject")
     @patch("eos_downloader.cli.get.utils.extract_ceos_versions")
     def test_docker_import_failure_returns_1(
-        self, mock_extract, mock_eos_xml, mock_soft_manager, mock_download_files, mock_docker
+        self,
+        mock_extract,
+        mock_eos_xml,
+        mock_soft_manager,
+        mock_download_files,
+        mock_docker,
     ):
         """Test failed docker import causes return code 1 (lines 411, 414-415)."""
         mock_extract.return_value = ["4.29.3M"]

--- a/tests/unit/helpers/test_helpers.py
+++ b/tests/unit/helpers/test_helpers.py
@@ -197,12 +197,25 @@ class TestSigintGuard:
             assert during != original
         assert signal.getsignal(signal.SIGINT) == original
 
-    def test_guard_sets_event_on_signal(self) -> None:
-        done = Event()
-        with sigint_guard(done):
-            handler = signal.getsignal(signal.SIGINT)
-            handler(signal.SIGINT, None)  # type: ignore[misc]
-        assert done.is_set()
+    def test_guard_sets_event_and_chains_to_previous(self) -> None:
+        calls: List[int] = []
+
+        def previous(signum: int, frame: Any) -> None:
+            calls.append(signum)
+
+        original = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, previous)
+        try:
+            done = Event()
+            with sigint_guard(done):
+                handler = signal.getsignal(signal.SIGINT)
+                handler(signal.SIGINT, None)  # type: ignore[misc]
+            # Event is set (workers stop) AND the previous handler still runs
+            # (interruption is not swallowed).
+            assert done.is_set()
+            assert calls == [signal.SIGINT]
+        finally:
+            signal.signal(signal.SIGINT, original)
 
 
 class TestStreamToFile:
@@ -220,9 +233,12 @@ class TestStreamToFile:
         mock_file.assert_called_once_with("/tmp/file.txt", "wb")
         assert mock_file().write.call_count > 0
 
+    @patch("eos_downloader.helpers.os.remove")
     @patch("eos_downloader.helpers.requests.get")
     @patch("builtins.open", new_callable=mock_open)
-    def test_interrupted_by_event(self, mock_file: Mock, mock_get: Mock) -> None:
+    def test_interrupted_by_event(
+        self, mock_file: Mock, mock_get: Mock, mock_remove: Mock
+    ) -> None:
         done = Event()
 
         def chunks(chunk_size: int) -> Any:
@@ -239,6 +255,8 @@ class TestStreamToFile:
             ("http://x/file.txt", "/tmp/file.txt", "file.txt"), NoopReporter(), done
         )
         assert interrupted is True
+        # The partial file is removed so it is not later treated as cached.
+        mock_remove.assert_called_once_with("/tmp/file.txt")
 
     @patch("eos_downloader.helpers.requests.get")
     @patch("builtins.open", new_callable=mock_open)
@@ -261,6 +279,47 @@ class TestStreamToFile:
                 Event(),
             )
         assert mock_get.call_args[1]["headers"] is not None
+
+    @patch("eos_downloader.helpers.requests.get")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_http_error_raises_before_writing(
+        self, mock_file: Mock, mock_get: Mock
+    ) -> None:
+        resp = _mock_response([b"data"], "4")
+        resp.raise_for_status.side_effect = requests.HTTPError("404")
+        mock_get.return_value = resp
+
+        with pytest.raises(requests.HTTPError):
+            _stream_to_file(
+                ("http://x/file.txt", "/tmp/file.txt", "file.txt"),
+                NoopReporter(),
+                Event(),
+            )
+        # No error page written to disk.
+        mock_file().write.assert_not_called()
+        resp.close.assert_called_once()
+
+    @patch("eos_downloader.helpers.requests.get")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_empty_keep_alive_chunks_skipped(
+        self, mock_file: Mock, mock_get: Mock
+    ) -> None:
+        mock_get.return_value = _mock_response([b"", b"data", b"", b"more"], "8")
+        _stream_to_file(
+            ("http://x/file.txt", "/tmp/file.txt", "file.txt"), NoopReporter(), Event()
+        )
+        # Only the two non-empty chunks are written.
+        assert mock_file().write.call_count == 2
+
+    @patch("eos_downloader.helpers.requests.get")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_response_closed_on_success(self, mock_file: Mock, mock_get: Mock) -> None:
+        resp = _mock_response([b"data"], "4")
+        mock_get.return_value = resp
+        _stream_to_file(
+            ("http://x/file.txt", "/tmp/file.txt", "file.txt"), NoopReporter(), Event()
+        )
+        resp.close.assert_called_once()
 
 
 class _RecordingReporter(DownloadReporter):

--- a/tests/unit/helpers/test_helpers.py
+++ b/tests/unit/helpers/test_helpers.py
@@ -4,411 +4,327 @@
 # pylint: disable=unused-argument
 # pylint: disable=protected-access
 
-"""
-Comprehensive tests for helpers/__init__.py module.
+"""Tests for the download progress reporter layer in helpers/__init__.py.
 
-Tests the DownloadProgressBar class and signal handling for file downloads.
+Covers reporter selection, the plain (non-TTY) reporter, the rich reporter,
+signal-handler scoping, single-file streaming and concurrent downloads.
 """
 
+import re
 import signal
-from pathlib import Path
+import time
 from threading import Event
-from typing import List
-from unittest.mock import Mock, MagicMock, patch, mock_open
+from typing import Any, Dict, List, Optional
+from unittest.mock import Mock, mock_open, patch
 
 import pytest
 import requests
+from loguru import logger
+from rich.console import Console
 
 from eos_downloader.helpers import (
-    DownloadProgressBar,
-    handle_sigint,
-    done_event,
-    console,
+    DownloadReporter,
+    NoopReporter,
+    PlainReporter,
+    RichReporter,
+    download_files_concurrently,
+    resolve_reporter,
+    sigint_guard,
+    _stream_to_file,
 )
 
-
-class TestSignalHandling:
-    """Test suite for signal handling functions."""
-
-    def test_handle_sigint_sets_done_event(self) -> None:
-        """Test that handle_sigint sets the done_event."""
-        # Arrange - create fresh event for testing
-        test_event = Event()
-        assert not test_event.is_set()
-
-        # Act - simulate SIGINT with mock event
-        with patch("eos_downloader.helpers.done_event", test_event):
-            handle_sigint(signal.SIGINT, None)
-
-        # Assert
-        assert test_event.is_set()
-
-    def test_handle_sigint_callable(self) -> None:
-        """Test that handle_sigint is callable with signal args."""
-        # Should not raise any exceptions
-        handle_sigint(signal.SIGINT, None)
-        handle_sigint(15, Mock())  # Any signal number
-
-    def test_console_instance_exists(self) -> None:
-        """Test that console instance is available."""
-        from eos_downloader.helpers import console
-        from rich.console import Console
-
-        assert console is not None
-        assert isinstance(console, Console)
-
-    def test_done_event_instance_exists(self) -> None:
-        """Test that done_event instance is available."""
-        from eos_downloader.helpers import done_event
-
-        assert done_event is not None
-        assert isinstance(done_event, Event)
+ANSI_RE = re.compile(r"\x1b\[")
 
 
-class TestDownloadProgressBar:
-    """Test suite for DownloadProgressBar class."""
+def _mock_response(chunks: List[bytes], content_length: Optional[str]) -> Mock:
+    """Build a mock streaming ``requests`` response."""
+    resp = Mock(spec=requests.Response)
+    resp.headers = {} if content_length is None else {"Content-Length": content_length}
+    resp.iter_content = lambda chunk_size: iter(chunks)
+    return resp
 
-    @pytest.fixture(autouse=True)
-    def reset_done_event(self) -> None:
-        """Ensure done_event is cleared before each test."""
-        done_event.clear()
-        yield
-        done_event.clear()  # Also clear after test
+
+class TestReporterSelection:
+    """resolve_reporter picks the right implementation."""
 
     @pytest.fixture
-    def progress_bar(self) -> DownloadProgressBar:
-        """Provide DownloadProgressBar instance."""
-        return DownloadProgressBar()
+    def tty_console(self) -> Console:
+        return Console(force_terminal=True)
 
     @pytest.fixture
-    def mock_response(self) -> Mock:
-        """Provide mock HTTP response."""
-        mock_resp = Mock(spec=requests.Response)
-        mock_resp.headers = {"Content-Length": "1024"}
+    def notty_console(self) -> Console:
+        return Console(force_terminal=False)
 
-        # iter_content should return a fresh iterator each time
-        def make_chunks(chunk_size):
-            """Generate chunks for each call."""
-            return iter([b"data" * 64 for _ in range(4)])
+    def test_auto_on_terminal_selects_rich(self, tty_console: Console) -> None:
+        assert isinstance(resolve_reporter("auto", tty_console), RichReporter)
 
-        mock_resp.iter_content = make_chunks
-        return mock_resp
+    def test_auto_off_terminal_selects_plain(self, notty_console: Console) -> None:
+        assert isinstance(resolve_reporter("auto", notty_console), PlainReporter)
 
-    def test_progress_bar_initialization(
-        self, progress_bar: DownloadProgressBar
-    ) -> None:
-        """Test DownloadProgressBar initializes correctly."""
-        from rich.progress import Progress
+    def test_explicit_rich_overrides_detection(self, notty_console: Console) -> None:
+        assert isinstance(resolve_reporter("rich", notty_console), RichReporter)
 
-        assert progress_bar is not None
-        assert hasattr(progress_bar, "progress")
-        assert isinstance(progress_bar.progress, Progress)
+    def test_explicit_plain_overrides_detection(self, tty_console: Console) -> None:
+        assert isinstance(resolve_reporter("plain", tty_console), PlainReporter)
 
-    def test_progress_bar_has_custom_columns(
-        self, progress_bar: DownloadProgressBar
-    ) -> None:
-        """Test that progress bar has custom columns configured."""
-        # Verify progress object has columns
-        assert progress_bar.progress is not None
-        # Should have multiple columns (text, bar, percentage, etc.)
-        assert len(progress_bar.progress.columns) > 0
+    def test_none_selects_noop(self, tty_console: Console) -> None:
+        assert isinstance(resolve_reporter("none", tty_console), NoopReporter)
 
-    @patch("requests.get")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_copy_url_success(
-        self,
-        mock_file: Mock,
-        mock_get: Mock,
-        progress_bar: DownloadProgressBar,
-        mock_response: Mock,
-    ) -> None:
-        """Test _copy_url downloads file successfully."""
-        # Arrange
-        mock_get.return_value = mock_response
-        task_id = progress_bar.progress.add_task("test", start=False)
 
-        # Act
-        result = progress_bar._copy_url(
-            task_id, "http://example.com/file.txt", "/tmp/file.txt"
+class TestNoopReporter:
+    """NoopReporter does nothing and never raises."""
+
+    def test_noop_lifecycle(self) -> None:
+        reporter = NoopReporter()
+        with reporter:
+            handle = reporter.add_file("file.swi", 100)
+            reporter.advance(handle, 50)
+            reporter.complete(handle)
+        assert handle is None
+
+
+class TestPlainReporter:
+    """PlainReporter emits ANSI-free loguru lifecycle lines."""
+
+    @pytest.fixture
+    def captured(self) -> List[str]:
+        """Capture the raw (unformatted) loguru message text of each record."""
+        messages: List[str] = []
+        sink_id = logger.add(
+            lambda message: messages.append(message.record["message"]), colorize=False
         )
+        yield messages
+        logger.remove(sink_id)
 
-        # Assert
-        assert result is False  # False means completed successfully
-        mock_get.assert_called_once()
+    def test_lifecycle_lines_emitted(self, captured: List[str]) -> None:
+        reporter = PlainReporter()
+        with reporter:
+            handle = reporter.add_file("EOS.swi", 100)
+            for _ in range(10):
+                reporter.advance(handle, 10)
+            reporter.complete(handle)
+
+        joined = "\n".join(captured)
+        assert "Downloading EOS.swi" in joined
+        assert "done in" in joined
+
+    def test_progress_reported_every_10_percent(self, captured: List[str]) -> None:
+        reporter = PlainReporter()
+        handle = reporter.add_file("EOS.swi", 100)
+        for _ in range(10):
+            reporter.advance(handle, 10)
+        reporter.complete(handle)
+
+        joined = "\n".join(captured)
+        # 10%..90% milestones (100% is covered by the completion line).
+        for milestone in range(10, 100, 10):
+            assert f"{milestone}%" in joined
+
+    def test_no_ansi_escape_sequences(self, captured: List[str]) -> None:
+        reporter = PlainReporter()
+        handle = reporter.add_file("EOS.swi", 100)
+        reporter.advance(handle, 50)
+        reporter.advance(handle, 50)
+        reporter.complete(handle)
+
+        for message in captured:
+            assert not ANSI_RE.search(message), f"ANSI sequence found in: {message!r}"
+
+    def test_unknown_size_does_not_crash(self, captured: List[str]) -> None:
+        reporter = PlainReporter()
+        handle = reporter.add_file("EOS.swi", None)
+        reporter.advance(handle, 500)
+        reporter.complete(handle)
+
+        joined = "\n".join(captured)
+        assert "unknown size" in joined
+
+
+class TestRichReporter:
+    """RichReporter aggregates files into one shared Progress."""
+
+    @pytest.fixture
+    def reporter(self) -> RichReporter:
+        return RichReporter(Console(force_terminal=True))
+
+    def test_add_file_aggregates_total(self, reporter: RichReporter) -> None:
+        reporter.add_file("a", 100)
+        reporter.add_file("b", 50)
+        total_task = next(
+            t for t in reporter._progress.tasks if t.id == reporter._total_task
+        )
+        assert total_task.total == 150
+
+    def test_unknown_size_makes_total_indeterminate(
+        self, reporter: RichReporter
+    ) -> None:
+        reporter.add_file("a", None)
+        total_task = next(
+            t for t in reporter._progress.tasks if t.id == reporter._total_task
+        )
+        assert total_task.total is None
+
+    def test_advance_updates_file_and_total(self, reporter: RichReporter) -> None:
+        handle = reporter.add_file("a", 100)
+        reporter.advance(handle, 40)
+        file_task = next(t for t in reporter._progress.tasks if t.id == handle)
+        total_task = next(
+            t for t in reporter._progress.tasks if t.id == reporter._total_task
+        )
+        assert file_task.completed == 40
+        assert total_task.completed == 40
+
+
+class TestSigintGuard:
+    """Signal handling is scoped, with no import-time side effect."""
+
+    def test_import_does_not_replace_sigint_handler(self) -> None:
+        # Re-importing the module must not have installed a global handler.
+        import importlib
+
+        import eos_downloader.helpers as helpers_module
+
+        before = signal.getsignal(signal.SIGINT)
+        importlib.reload(helpers_module)
+        after = signal.getsignal(signal.SIGINT)
+        assert before == after
+
+    def test_guard_installs_then_restores_handler(self) -> None:
+        original = signal.getsignal(signal.SIGINT)
+        done = Event()
+        with sigint_guard(done):
+            during = signal.getsignal(signal.SIGINT)
+            assert during != original
+        assert signal.getsignal(signal.SIGINT) == original
+
+    def test_guard_sets_event_on_signal(self) -> None:
+        done = Event()
+        with sigint_guard(done):
+            handler = signal.getsignal(signal.SIGINT)
+            handler(signal.SIGINT, None)  # type: ignore[misc]
+        assert done.is_set()
+
+
+class TestStreamToFile:
+    """_stream_to_file streams a single file into a reporter."""
+
+    @patch("eos_downloader.helpers.requests.get")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_success(self, mock_file: Mock, mock_get: Mock) -> None:
+        mock_get.return_value = _mock_response([b"data" * 64] * 4, "1024")
+        reporter = NoopReporter()
+        interrupted = _stream_to_file(
+            ("http://x/file.txt", "/tmp/file.txt", "file.txt"), reporter, Event()
+        )
+        assert interrupted is False
         mock_file.assert_called_once_with("/tmp/file.txt", "wb")
-        # Verify data was written
         assert mock_file().write.call_count > 0
 
-    @patch("requests.get")
+    @patch("eos_downloader.helpers.requests.get")
     @patch("builtins.open", new_callable=mock_open)
-    def test_copy_url_with_custom_block_size(
-        self,
-        mock_file: Mock,
-        mock_get: Mock,
-        progress_bar: DownloadProgressBar,
-        mock_response: Mock,
-    ) -> None:
-        """Test _copy_url with custom block size."""
-        mock_get.return_value = mock_response
-        task_id = progress_bar.progress.add_task("test", start=False)
+    def test_interrupted_by_event(self, mock_file: Mock, mock_get: Mock) -> None:
+        done = Event()
 
-        # Wrap iter_content to track calls while keeping functionality
-        original_iter_content = mock_response.iter_content
-        mock_response.iter_content = Mock(side_effect=original_iter_content)
-
-        result = progress_bar._copy_url(
-            task_id,
-            "http://example.com/file.txt",
-            "/tmp/file.txt",
-            block_size=2048,
-        )
-
-        assert result is False
-        # Verify iter_content called with custom block size
-        mock_response.iter_content.assert_called_with(chunk_size=2048)
-
-    @patch("requests.get")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_copy_url_interrupted_by_done_event(
-        self,
-        mock_file: Mock,
-        mock_get: Mock,
-        progress_bar: DownloadProgressBar,
-    ) -> None:
-        """Test _copy_url respects done_event interruption."""
-        # Arrange - create response that sets done_event mid-download
-        mock_resp = Mock()
-        mock_resp.headers = {"Content-Length": "1024"}
-
-        def iter_with_interrupt(chunk_size: int):
-            """Simulate interrupt after first chunk."""
+        def chunks(chunk_size: int) -> Any:
             yield b"data1"
-            done_event.set()  # Interrupt
-            yield b"data2"  # This shouldn't be written
+            done.set()
+            yield b"data2"
 
-        mock_resp.iter_content = iter_with_interrupt
-        mock_get.return_value = mock_resp
-        task_id = progress_bar.progress.add_task("test", start=False)
+        resp = Mock()
+        resp.headers = {"Content-Length": "1024"}
+        resp.iter_content = chunks
+        mock_get.return_value = resp
 
-        try:
-            # Act
-            result = progress_bar._copy_url(
-                task_id, "http://example.com/file.txt", "/tmp/file.txt"
-            )
+        interrupted = _stream_to_file(
+            ("http://x/file.txt", "/tmp/file.txt", "file.txt"), NoopReporter(), done
+        )
+        assert interrupted is True
 
-            # Assert - should return True for interrupted
-            assert result is True
-        finally:
-            # Cleanup - clear the event
-            done_event.clear()
-
-    @patch("requests.get")
-    def test_copy_url_handles_missing_content_length(
-        self,
-        mock_get: Mock,
-        progress_bar: DownloadProgressBar,
-    ) -> None:
-        """Test _copy_url raises error when Content-Length missing."""
-        # Arrange
-        mock_resp = Mock()
-        mock_resp.headers = {}  # No Content-Length
-        mock_get.return_value = mock_resp
-        task_id = progress_bar.progress.add_task("test", start=False)
-
-        # Act & Assert
-        with pytest.raises(KeyError):
-            progress_bar._copy_url(
-                task_id, "http://example.com/file.txt", "/tmp/file.txt"
-            )
-
-    @patch("requests.get")
-    def test_copy_url_handles_network_error(
-        self,
-        mock_get: Mock,
-        progress_bar: DownloadProgressBar,
-    ) -> None:
-        """Test _copy_url handles network errors."""
-        # Arrange
-        mock_get.side_effect = requests.RequestException("Network error")
-        task_id = progress_bar.progress.add_task("test", start=False)
-
-        # Act & Assert
-        with pytest.raises(requests.RequestException):
-            progress_bar._copy_url(
-                task_id, "http://example.com/file.txt", "/tmp/file.txt"
-            )
-
-    @patch("requests.get")
+    @patch("eos_downloader.helpers.requests.get")
     @patch("builtins.open", new_callable=mock_open)
-    def test_copy_url_updates_progress(
-        self,
-        mock_file: Mock,
-        mock_get: Mock,
-        progress_bar: DownloadProgressBar,
-        mock_response: Mock,
+    def test_missing_content_length_does_not_crash(
+        self, mock_file: Mock, mock_get: Mock
     ) -> None:
-        """Test that _copy_url updates progress correctly."""
-        mock_get.return_value = mock_response
-        task_id = progress_bar.progress.add_task("test", start=False)
+        mock_get.return_value = _mock_response([b"data"], None)
+        interrupted = _stream_to_file(
+            ("http://x/file.txt", "/tmp/file.txt", "file.txt"), NoopReporter(), Event()
+        )
+        assert interrupted is False
 
-        with patch.object(progress_bar.progress, "update") as mock_update:
-            progress_bar._copy_url(
-                task_id, "http://example.com/file.txt", "/tmp/file.txt"
+    @patch("eos_downloader.helpers.requests.get")
+    def test_default_headers_sent(self, mock_get: Mock) -> None:
+        mock_get.return_value = _mock_response([b"data"], "4")
+        with patch("builtins.open", new_callable=mock_open):
+            _stream_to_file(
+                ("http://x/file.txt", "/tmp/file.txt", "file.txt"),
+                NoopReporter(),
+                Event(),
             )
+        assert mock_get.call_args[1]["headers"] is not None
 
-            # Verify progress.update was called
-            assert mock_update.call_count > 0
-            # First call should set total
-            first_call = mock_update.call_args_list[0]
-            assert "total" in first_call[1]
 
-    @patch.object(DownloadProgressBar, "_copy_url")
-    def test_download_single_url(
-        self,
-        mock_copy: Mock,
-        progress_bar: DownloadProgressBar,
-        tmp_path: Path,
-    ) -> None:
-        """Test download method with single URL."""
-        # Arrange
-        mock_copy.return_value = False
-        urls = ["http://example.com/file.txt"]
+class _RecordingReporter(DownloadReporter):
+    """Reporter that records add_file/advance/complete calls thread-safely."""
 
-        # Act
-        progress_bar.download(urls, str(tmp_path))
+    def __init__(self) -> None:
+        self.added: List[str] = []
+        self.completed: List[str] = []
+        self._names: Dict[int, str] = {}
+        self._counter = 0
 
-        # Assert
-        mock_copy.assert_called_once()
-        call_args = mock_copy.call_args
-        assert "http://example.com/file.txt" in call_args[0]
-        assert str(tmp_path) in call_args[0][2]
+    def add_file(self, name: str, total: Optional[int]) -> int:
+        handle = self._counter
+        self._counter += 1
+        self._names[handle] = name
+        self.added.append(name)
+        return handle
 
-    @patch.object(DownloadProgressBar, "_copy_url")
-    def test_download_multiple_urls(
-        self,
-        mock_copy: Mock,
-        progress_bar: DownloadProgressBar,
-        tmp_path: Path,
-    ) -> None:
-        """Test download method with multiple URLs."""
-        mock_copy.return_value = False
-        urls = [
-            "http://example.com/file1.txt",
-            "http://example.com/file2.txt",
-            "http://example.com/file3.txt",
+    def advance(self, handle: int, n_bytes: int) -> None:
+        return None
+
+    def complete(self, handle: int) -> None:
+        self.completed.append(self._names[handle])
+
+
+class TestDownloadFilesConcurrently:
+    """download_files_concurrently drives one shared reporter over many files."""
+
+    @patch("eos_downloader.helpers.requests.get")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_all_files_completed(self, mock_file: Mock, mock_get: Mock) -> None:
+        mock_get.return_value = _mock_response([b"data"], "4")
+        reporter = _RecordingReporter()
+        items = [
+            ("http://x/image.swi", "/tmp/image.swi", "image.swi"),
+            ("http://x/image.sha512", "/tmp/image.sha512", "image.sha512"),
         ]
+        download_files_concurrently(items, reporter)
 
-        progress_bar.download(urls, str(tmp_path))
+        assert set(reporter.added) == {"image.swi", "image.sha512"}
+        assert set(reporter.completed) == {"image.swi", "image.sha512"}
 
-        assert mock_copy.call_count == 3
+    def test_empty_list_is_noop(self) -> None:
+        reporter = _RecordingReporter()
+        download_files_concurrently([], reporter)
+        assert reporter.added == []
 
-    @patch.object(DownloadProgressBar, "_copy_url")
-    def test_download_extracts_filename_from_url(
-        self,
-        mock_copy: Mock,
-        progress_bar: DownloadProgressBar,
-        tmp_path: Path,
-    ) -> None:
-        """Test that download correctly extracts filename from URL."""
-        mock_copy.return_value = False
-        urls = ["http://example.com/path/to/myfile.zip?param=value"]
-
-        progress_bar.download(urls, str(tmp_path))
-
-        # Verify filename was extracted correctly
-        call_args = mock_copy.call_args[0]
-        dest_path = call_args[2]
-        assert "myfile.zip" in dest_path
-        assert "param" not in dest_path  # Query params removed
-
-    @patch.object(DownloadProgressBar, "_copy_url")
-    def test_download_handles_url_without_extension(
-        self,
-        mock_copy: Mock,
-        progress_bar: DownloadProgressBar,
-        tmp_path: Path,
-    ) -> None:
-        """Test download handles URLs without file extension."""
-        mock_copy.return_value = False
-        urls = ["http://example.com/download"]
-
-        progress_bar.download(urls, str(tmp_path))
-
-        call_args = mock_copy.call_args[0]
-        dest_path = call_args[2]
-        assert "download" in dest_path
-
-    @patch.object(DownloadProgressBar, "_copy_url")
-    def test_download_concurrent_execution(
-        self,
-        mock_copy: Mock,
-        progress_bar: DownloadProgressBar,
-        tmp_path: Path,
-    ) -> None:
-        """Test that download uses ThreadPoolExecutor."""
-        # Make _copy_url slower to test concurrency
-        import time
-
-        def slow_copy(*args, **kwargs):
-            time.sleep(0.1)
-            return False
-
-        mock_copy.side_effect = slow_copy
-        urls = [f"http://example.com/file{i}.txt" for i in range(5)]
-
-        import time
-
-        start = time.time()
-        progress_bar.download(urls, str(tmp_path))
-        duration = time.time() - start
-
-        # With ThreadPoolExecutor, should be faster than sequential
-        # Sequential would be ~0.5s, concurrent should be ~0.1-0.2s
-        assert duration < 0.3  # Allow some overhead
-        assert mock_copy.call_count == 5
-
-    @patch.object(DownloadProgressBar, "_copy_url")
-    def test_download_waits_for_all_futures(
-        self,
-        mock_copy: Mock,
-        progress_bar: DownloadProgressBar,
-        tmp_path: Path,
-    ) -> None:
-        """Test that download waits for all downloads to complete."""
-        completed: List[int] = []
-
-        def track_completion(task_id, url, path):
-            import time
-
-            time.sleep(0.05)
-            completed.append(1)
-            return False
-
-        mock_copy.side_effect = track_completion
-        urls = [f"http://example.com/file{i}.txt" for i in range(3)]
-
-        progress_bar.download(urls, str(tmp_path))
-
-        # All should be completed
-        assert len(completed) == 3
-
-    @patch("requests.get")
+    @patch("eos_downloader.helpers.requests.get")
     @patch("builtins.open", new_callable=mock_open)
-    def test_copy_url_includes_default_headers(
-        self,
-        mock_file: Mock,
-        mock_get: Mock,
-        progress_bar: DownloadProgressBar,
-        mock_response: Mock,
-    ) -> None:
-        """Test that _copy_url includes default request headers."""
-        mock_get.return_value = mock_response
-        task_id = progress_bar.progress.add_task("test", start=False)
+    def test_runs_concurrently(self, mock_file: Mock, mock_get: Mock) -> None:
+        def slow_get(*args: Any, **kwargs: Any) -> Mock:
+            resp = Mock()
+            resp.headers = {"Content-Length": "4"}
 
-        progress_bar._copy_url(task_id, "http://example.com/file.txt", "/tmp/file.txt")
+            def chunks(chunk_size: int) -> Any:
+                time.sleep(0.1)
+                yield b"data"
 
-        # Verify headers were passed
-        call_kwargs = mock_get.call_args[1]
-        assert "headers" in call_kwargs
-        # Should include default headers
-        assert call_kwargs["headers"] is not None
+            resp.iter_content = chunks
+            return resp
+
+        mock_get.side_effect = slow_get
+        items = [(f"http://x/file{i}", f"/tmp/file{i}", f"file{i}") for i in range(4)]
+        start = time.time()
+        download_files_concurrently(items, NoopReporter())
+        # 4 files sequential ≈ 0.4s; concurrent (4 workers) should be well under.
+        assert time.time() - start < 0.3

--- a/tests/unit/logics/test_download.py
+++ b/tests/unit/logics/test_download.py
@@ -1,10 +1,36 @@
 import os
 import subprocess
+import warnings
 import pytest
 from unittest.mock import Mock, patch, mock_open
 from pathlib import Path
-from eos_downloader.logics.download import SoftManager
+from eos_downloader.logics.download import SoftManager, _resolve_progress_mode
 from eos_downloader.logics.arista_xml_server import EosXmlObject
+
+
+class TestResolveProgressMode:
+    """Tests for the progress-mode resolution and deprecated alias."""
+
+    def test_explicit_mode_passthrough(self):
+        assert _resolve_progress_mode("plain", None) == "plain"
+
+    def test_rich_interface_false_maps_to_plain(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert _resolve_progress_mode("auto", False) == "plain"
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+    def test_rich_interface_true_maps_to_auto(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert _resolve_progress_mode("auto", True) == "auto"
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+    def test_no_alias_emits_no_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _resolve_progress_mode("rich", None)
+        assert not caught
 
 
 @pytest.fixture
@@ -47,21 +73,6 @@ def test_soft_manager_init(dry_run, force_download):
     assert manager.dry_run == dry_run
     assert manager.force_download == force_download
     assert manager.file == {"name": None, "md5sum": None, "sha512sum": None}
-
-
-@patch("requests.get")
-@patch("tqdm.tqdm")
-def test_download_file_raw(mock_tqdm, mock_requests):
-    # Setup mock response
-    mock_response = Mock()
-    mock_response.headers = {"Content-Length": "1024"}
-    mock_response.iter_content.return_value = [b"data"]
-    mock_requests.return_value = mock_response
-
-    with patch("builtins.open", mock_open()) as mock_file:
-        result = SoftManager._download_file_raw("http://test.com/file", "/tmp/file")
-        assert result == "/tmp/file"
-        mock_file().write.assert_called_with(b"data")
 
 
 @patch("os.makedirs")
@@ -112,27 +123,29 @@ def test_compute_hash_md5sum(soft_manager):
 #                 soft_manager.checksum(check_type)
 
 
-@patch("eos_downloader.logics.download.SoftManager._download_file_raw")
-@patch("eos_downloader.helpers.DownloadProgressBar")
-def test_download_file(mock_progress_bar, mock_download_raw, soft_manager):
+@patch("eos_downloader.logics.download.download_files_concurrently")
+def test_download_file(mock_download, soft_manager):
     url = "http://test.com/file"
     file_path = "/tmp"
     filename = "test.swi"
 
-    # Test with rich interface
-    result = soft_manager.download_file(url, file_path, filename, rich_interface=True)
+    result = soft_manager.download_file(url, file_path, filename)
     assert result == os.path.join(file_path, filename)
-    mock_progress_bar.assert_called_once()
+    mock_download.assert_called_once()
+    # The single file is streamed as one (url, dest, name) item.
+    items = list(mock_download.call_args[0][0])
+    assert items == [(url, os.path.join(file_path, filename), filename)]
 
 
-@patch("eos_downloader.logics.download.SoftManager.download_file")
+@patch("eos_downloader.logics.download.download_files_concurrently")
 def test_downloads(mock_download, soft_manager, mock_eos_object):
-    path, was_cached = soft_manager.downloads(
-        mock_eos_object, "/tmp/downloads", rich_interface=True
-    )
+    path, was_cached = soft_manager.downloads(mock_eos_object, "/tmp/downloads")
     assert path == "/tmp/downloads"
     assert isinstance(was_cached, bool)
-    assert mock_download.call_count == len(mock_eos_object.urls)
+    # One shared concurrent batch for all (non-cached) files, not one call per file.
+    mock_download.assert_called_once()
+    items = list(mock_download.call_args[0][0])
+    assert len(items) == len(mock_eos_object.urls)
 
 
 @patch("shutil.which")
@@ -229,14 +242,14 @@ class TestFileCache:
         assert result is False
 
     @patch("pathlib.Path.exists")
-    @patch("eos_downloader.logics.download.SoftManager._download_file_raw")
+    @patch("eos_downloader.logics.download.download_files_concurrently")
     def test_download_file_uses_cache(self, mock_download, mock_exists):
         """Test that download_file uses cached file when available."""
         mock_exists.return_value = True
         manager = SoftManager()
 
         cached_path = manager.download_file(
-            "http://test.com/file.swi", "/tmp", "test.swi", rich_interface=False
+            "http://test.com/file.swi", "/tmp", "test.swi", progress="none"
         )
 
         # Should return cached path without downloading
@@ -244,15 +257,14 @@ class TestFileCache:
         mock_download.assert_not_called()
 
     @patch("pathlib.Path.exists")
-    @patch("eos_downloader.logics.download.SoftManager._download_file_raw")
+    @patch("eos_downloader.logics.download.download_files_concurrently")
     def test_download_file_bypasses_cache_with_force(self, mock_download, mock_exists):
         """Test that force flag bypasses cache."""
         mock_exists.return_value = True
-        mock_download.return_value = "/tmp/test.swi"
         manager = SoftManager(force_download=True)
 
         downloaded_path = manager.download_file(
-            "http://test.com/file.swi", "/tmp", "test.swi", rich_interface=False
+            "http://test.com/file.swi", "/tmp", "test.swi", progress="none"
         )
 
         # Should download despite cache
@@ -260,18 +272,17 @@ class TestFileCache:
         mock_download.assert_called_once()
 
     @patch("pathlib.Path.exists")
-    @patch("eos_downloader.logics.download.SoftManager._download_file_raw")
+    @patch("eos_downloader.logics.download.download_files_concurrently")
     def test_download_file_force_parameter(self, mock_download, mock_exists):
         """Test that force parameter overrides cache."""
         mock_exists.return_value = True
-        mock_download.return_value = "/tmp/test.swi"
         manager = SoftManager()
 
         forced_path = manager.download_file(
             "http://test.com/file.swi",
             "/tmp",
             "test.swi",
-            rich_interface=False,
+            progress="none",
             force=True,
         )
 
@@ -406,9 +417,11 @@ class TestDockerCache:
 class TestCacheIntegration:
     """Integration tests for cache functionality."""
 
-    @patch("eos_downloader.logics.download.SoftManager.download_file")
-    def test_downloads_propagates_force_flag(self, mock_download):
-        """Test that downloads() propagates force_download to download_file."""
+    @patch("pathlib.Path.exists")
+    @patch("eos_downloader.logics.download.download_files_concurrently")
+    def test_downloads_force_flag_bypasses_cache(self, mock_download, mock_exists):
+        """With force_download, an existing file is still (re-)downloaded."""
+        mock_exists.return_value = True  # File exists on disk
         mock_eos = Mock()
         mock_eos.version = "4.29.3M"
         mock_eos.filename = "test.swi"
@@ -418,12 +431,10 @@ class TestCacheIntegration:
         manager = SoftManager(force_download=True)
         path, was_cached = manager.downloads(mock_eos, "/tmp")
 
-        # Verify force was passed to download_file
-        mock_download.assert_called()
-        call_kwargs = mock_download.call_args[1]
-        assert call_kwargs.get("force") is True
+        # Cache is bypassed: the file is scheduled for download, not reported cached.
+        mock_download.assert_called_once()
+        assert was_cached is False
         assert path == "/tmp"
-        assert isinstance(was_cached, bool)
 
     @patch("pathlib.Path.exists")
     def test_dry_run_with_cache(self, mock_exists):
@@ -521,7 +532,7 @@ class TestDownloadFileEdgeCases:
             url=False,
             file_path="/tmp",
             filename="test.swi",
-            rich_interface=False,
+            progress="none",
         )
         assert result is None
 
@@ -532,7 +543,7 @@ class TestDownloadFileEdgeCases:
             url="http://test.com/file.swi",
             file_path="/tmp",
             filename="test.swi",
-            rich_interface=False,
+            progress="none",
         )
         assert result == "/tmp/test.swi"
 
@@ -733,7 +744,9 @@ class TestImportDockerCalledProcessError:
     @patch("subprocess.run")
     @patch("shutil.which")
     @patch("os.path.exists")
-    def test_import_docker_called_process_error(self, mock_exists, mock_which, mock_run):
+    def test_import_docker_called_process_error(
+        self, mock_exists, mock_which, mock_run
+    ):
         """Test import_docker raises RuntimeError on CalledProcessError."""
         mock_exists.return_value = True
         mock_which.return_value = "/usr/bin/docker"

--- a/uv.lock
+++ b/uv.lock
@@ -641,7 +641,6 @@ dependencies = [
     { name = "rich" },
     { name = "scp" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "tqdm" },
     { name = "typer" },
     { name = "urllib3" },
 ]
@@ -739,7 +738,6 @@ requires-dist = [
     { name = "scp" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "tox", marker = "extra == 'dev'", specifier = ">=4.11" },
-    { name = "tqdm" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "types-paramiko", marker = "extra == 'dev'" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
@@ -2136,18 +2134,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/bf/0e4dbd42724cbae25959f0e34c95d0c730df03ab03f54d52accd9abfc614/tox-4.32.0.tar.gz", hash = "sha256:1ad476b5f4d3679455b89a992849ffc3367560bbc7e9495ee8a3963542e7c8ff", size = 203330, upload-time = "2025-10-24T18:03:38.132Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/cc/e09c0d663a004945f82beecd4f147053567910479314e8d01ba71e5d5dea/tox-4.32.0-py3-none-any.whl", hash = "sha256:451e81dc02ba8d1ed20efd52ee409641ae4b5d5830e008af10fe8823ef1bd551", size = 175905, upload-time = "2025-10-24T18:03:36.337Z" },
-]
-
-[[package]]
-name = "tqdm"
-version = "4.67.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Rework the download progress display around a DownloadReporter abstraction
selected automatically from console.is_terminal:

- RichReporter: one shared rich.progress.Progress in a titled Panel with a
  per-file bar, spinner, ETA and an aggregated Total bar (no more per-file
  flicker).
- PlainReporter: ANSI-free loguru lifecycle lines (start, 10% milestones,
  completion) for non-TTY / CI.
- One shared Console threaded from the CLI into SoftManager.
- Files of a single download are fetched concurrently via the existing
  ThreadPoolExecutor.

Replace rich_interface with progress="auto"|"rich"|"plain"|"none"; keep
rich_interface as a deprecated alias (False->plain, True->auto) emitting a
DeprecationWarning. Add a CLI --no-progress flag on eos/cvp/path.

Remove the dead tqdm raw-download path and the tqdm dependency, and move the
SIGINT handler out of import time into a scoped guard.

Specs synced to openspec/specs/download-progress; change archived.

