### PR TITLE
feat(eos_downloader.cli): add --interactive wizard to get eos/cvp

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A project to download Arista softwares to local folder, Cloudvision or EVE-NG. I
 - 📦 **Multiple Formats**: Support for EOS (64-bit, vEOS, cEOS) and CloudVision Portal
 - 🐳 **Docker Integration**: Direct import to Docker/Podman registries
 - 🔧 **EVE-NG Support**: Automated provisioning for network simulation
+- 🧭 **Interactive Mode**: Guided wizard (`--interactive`) to pick format, version and options without memorizing flags
 - ⚡ **Fast Iterations**: Subsequent runs complete instantly using cached resources
 
 <img src='docs/imgs/logo.jpg' class="center" width="800px" />
@@ -62,6 +63,9 @@ ardl get eos --version 4.35.1F --format vEOS64-lab-qcow2
 
 # Force re-download/re-import (bypass cache)
 ardl get eos --version 4.29.4M --import-docker --force
+
+# Don't know the flags? Use the interactive wizard
+ardl get eos --interactive
 ```
 
 ### Smart Caching

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,9 @@ ardl get eos --version 4.35.1F --format vEOS64-lab-qcow2
 
 # Download all cEOS images from a containerlab topology
 ardl get eos --clab topology.clab.yml --format cEOS
+
+# Don't know the flags? Use the interactive wizard
+ardl get eos --interactive
 ```
 
 ## Author

--- a/docs/usage/cvp.md
+++ b/docs/usage/cvp.md
@@ -10,6 +10,20 @@ ardl get cvp --latest --format ova
 ardl get eos --branch 4.29 --format upgrade
 ```
 
+## Interactive mode
+
+Use `--interactive` (`-i`) to open a guided wizard that lets you pick the format,
+branch and version with the arrow keys (CVP has no release type), choose the
+output directory and a force-re-download toggle, then confirms with the
+equivalent command before downloading.
+
+```bash
+ardl get cvp --interactive
+```
+
+`--interactive` requires an interactive terminal and a token, and cannot be
+combined with `--version`, `--latest` or `--branch`.
+
 ## ardl get eos options
 
 Below are all the options available to get EOS package:
@@ -27,9 +41,14 @@ Options:
   --latest        Get latest version. If --branch is not use, get the latest
                   branch with specific release type  [env var:
                   ARISTA_GET_CVP_LATEST]
-  --version TEXT  EOS version to download  [env var: ARISTA_GET_CVP_VERSION]
-  --branch TEXT   Branch to download  [env var: ARISTA_GET_CVP_BRANCH]
-  --dry-run       Enable dry-run mode: only run code without system changes
+  --version TEXT      EOS version to download  [env var: ARISTA_GET_CVP_VERSION]
+  --branch TEXT       Branch to download  [env var: ARISTA_GET_CVP_BRANCH]
+  --dry-run           Enable dry-run mode: only run code without system changes
+  --force             Force download even if cached files exist  [env var:
+                      ARISTA_GET_CVP_FORCE]
+  --no-progress       Disable the download progress display (useful for
+                      CI/non-TTY)
+  --interactive, -i   Open a guided wizard to pick format, version and options
   --help
 ```
 

--- a/docs/usage/eos.md
+++ b/docs/usage/eos.md
@@ -32,6 +32,24 @@ ardl get eos --version 4.29.4M --force
 ardl get eos --version 4.29.4M --import-docker --force
 ```
 
+## Interactive mode
+
+If you don't know the exact flags, use `--interactive` (`-i`) to open a guided
+wizard. It lets you pick, with the arrow keys, the image format, the release type
+(`F`/`M`), the branch and the version, then offers format-dependent options
+(Docker import for cEOS images, EVE-NG provisioning for vEOS images), the output
+directory and a force-re-download toggle. Before downloading, it shows the
+equivalent command and asks for confirmation.
+
+```bash
+ardl get eos --interactive
+# or the short form
+ardl get eos -i
+```
+
+`--interactive` requires an interactive terminal and a token, and cannot be
+combined with `--version`, `--latest` or `--branch`.
+
 ## Smart Caching
 
 **eos-downloader** includes intelligent caching to avoid redundant downloads and Docker imports:
@@ -123,6 +141,10 @@ Options:
   --force                         Force download/import even if cached files
                                   or Docker images exist  [env var:
                                   ARISTA_GET_EOS_FORCE]
+  --no-progress                   Disable the download progress display
+                                  (useful for CI/non-TTY)
+  --interactive, -i               Open a guided wizard to pick format, version
+                                  and options
   --containerlab-topology, --clab FILE
                                   Path to containerlab topology file to
                                   download all cEOS images.

--- a/eos_downloader/cli/get/commands.py
+++ b/eos_downloader/cli/get/commands.py
@@ -37,6 +37,7 @@ from .utils import (
     handle_docker_import,
     download_from_containerlab_topology,
 )
+from .interactive import run_interactive, require_interactive_context
 
 app = typer.Typer(
     cls=AliasedTyperGroup,
@@ -123,6 +124,12 @@ def eos(
         "--no-progress",
         help="Disable the download progress display (useful for CI/non-TTY)",
     ),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Open a guided wizard to pick format, version and options",
+    ),
     containerlab_topology: Optional[Path] = typer.Option(
         None,
         "--containerlab-topology",
@@ -138,7 +145,24 @@ def eos(
     console, token, debug, log_level = initialize(ctx)
     progress: ProgressMode = "none" if no_progress else "auto"
 
-    if containerlab_topology is not None:
+    if interactive:
+        if version is not None or latest or branch is not None:
+            raise typer.BadParameter(
+                "--interactive is mutually exclusive with --version, --latest, and --branch"
+            )
+        require_interactive_context(console, token)
+        result = run_interactive("eos", console, token, output)
+        if result is None:
+            raise typer.Exit()
+        format = result.image_format
+        version = result.version
+        output = result.output
+        force = result.force
+        import_docker = result.import_docker
+        docker_name = result.docker_name
+        docker_tag = result.docker_tag
+        eve_ng = result.eve_ng
+    elif containerlab_topology is not None:
         if version is not None or latest or branch is not None:
             raise typer.BadParameter(
                 "--containerlab-topology is mutually exclusive with --version, --latest, and --branch"
@@ -166,9 +190,10 @@ def eos(
             progress=progress,
         )
 
-    version = search_version(
-        console, token, version, latest, branch, format, release_type
-    )
+    if not interactive:
+        version = search_version(
+            console, token, version, latest, branch, format, release_type
+        )
     if version is None:
         raise ValueError("Version is not set correctly")
     try:
@@ -264,11 +289,31 @@ def cvp(
         "--no-progress",
         help="Disable the download progress display (useful for CI/non-TTY)",
     ),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Open a guided wizard to pick format, version and options",
+    ),
 ) -> int:
     """Download CVP image from Arista server."""
     # pylint: disable=unused-variable
     console, token, debug, log_level = initialize(ctx)
     progress: ProgressMode = "none" if no_progress else "auto"
+
+    if interactive:
+        if version is not None or latest or branch is not None:
+            raise typer.BadParameter(
+                "--interactive is mutually exclusive with --version, --latest, and --branch"
+            )
+        require_interactive_context(console, token)
+        result = run_interactive("cvp", console, token, output)
+        if result is None:
+            raise typer.Exit()
+        format = result.image_format
+        version = result.version
+        output = result.output
+        force = result.force
 
     if version is not None:
         console.print(

--- a/eos_downloader/cli/get/interactive.py
+++ b/eos_downloader/cli/get/interactive.py
@@ -10,8 +10,9 @@ reuse its normal download path.
 
 from __future__ import annotations
 
+import shlex
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import questionary
 import typer
@@ -42,23 +43,32 @@ class InteractiveResult:  # pylint: disable=too-many-instance-attributes
     eve_ng: bool = False
 
     def to_command(self) -> str:
-        """Render the equivalent non-interactive ``ardl get`` command."""
-        parts: List[str] = [
-            f"ardl get {self.package}",
-            f"--format {self.image_format}",
-            f"--version {self.version}",
-            f"--output {self.output}",
+        """Render the equivalent non-interactive ``ardl get`` command.
+
+        Arguments are quoted with :func:`shlex.join` so the recap stays accurate
+        and copy/paste-safe even when values contain spaces or shell
+        metacharacters.
+        """
+        args: List[str] = [
+            "ardl",
+            "get",
+            self.package,
+            "--format",
+            self.image_format,
+            "--version",
+            self.version,
+            "--output",
+            self.output,
         ]
         if self.force:
-            parts.append("--force")
+            args.append("--force")
         if self.import_docker:
-            parts.append("--import-docker")
-            parts.append(f"--docker-name {self.docker_name}")
+            args += ["--import-docker", "--docker-name", self.docker_name]
             if self.docker_tag:
-                parts.append(f"--docker-tag {self.docker_tag}")
+                args += ["--docker-tag", self.docker_tag]
         if self.eve_ng:
-            parts.append("--eve-ng")
-        return " ".join(parts)
+            args.append("--eve-ng")
+        return shlex.join(args)
 
 
 def require_interactive_context(console: Console, token: Optional[str]) -> None:
@@ -95,6 +105,18 @@ def _formats_for(package: AristaPackage) -> List[str]:
     return [fmt for fmt in mapping.keys() if fmt != "default"]
 
 
+class _Aborted(Exception):
+    """Raised internally when the user cancels a prompt (Ctrl+C)."""
+
+
+def _ask(prompt: Any) -> Any:
+    """Return the prompt's answer, or abort the wizard if it was cancelled."""
+    answer = prompt.ask()
+    if answer is None:
+        raise _Aborted
+    return answer
+
+
 def run_interactive(
     package: AristaPackage,
     console: Console,
@@ -122,81 +144,95 @@ def run_interactive(
     """
     querier = AristaXmlQuerier(token=token)
 
-    # 1. Format
-    image_format = questionary.select(
-        "Select image format:", choices=_formats_for(package)
-    ).ask()
-    if image_format is None:
-        return None
-
-    # 2. Release type (EOS only)
-    rtype: Optional[str] = None
-    if package == "eos":
-        rtype = questionary.select("Select release type:", choices=RTYPES).ask()
-        if rtype is None:
-            return None
-
-    # 3. Branch
-    branches = querier.branches(package=package)
-    if not branches:
-        console.print("[red]No branches found for this package.[/red]")
-        return None
-    branch = questionary.select("Select branch:", choices=branches).ask()
-    if branch is None:
-        return None
-
-    # 4. Version (newest first)
-    versions = querier.available_public_versions(
-        branch=branch, rtype=rtype, package=package
-    )
-    version_choices = [str(v) for v in sorted(versions, reverse=True)]
-    if not version_choices:
-        console.print(
-            f"[red]No versions found for branch {branch} "
-            f"with the selected criteria.[/red]"
+    # A cancelled prompt (Ctrl+C -> ``.ask()`` returns None) raises _Aborted via
+    # _ask(), which is caught here to abort the whole wizard consistently.
+    try:
+        # 1. Format
+        image_format = _ask(
+            questionary.select("Select image format:", choices=_formats_for(package))
         )
-        return None
-    version = questionary.select("Select version:", choices=version_choices).ask()
-    if version is None:
-        return None
 
-    result = InteractiveResult(
-        package=package,
-        image_format=image_format,
-        version=version,
-        output=output_default,
-    )
+        # 2. Release type (EOS only)
+        rtype: Optional[str] = None
+        if package == "eos":
+            rtype = _ask(questionary.select("Select release type:", choices=RTYPES))
 
-    # 5. Format-dependent options (EOS only)
-    if package == "eos":
-        if image_format in CEOS_FORMATS:
-            if questionary.confirm("Import into Docker?", default=False).ask():
-                result.import_docker = True
-                result.docker_name = (
-                    questionary.text("Docker image name:", default="arista/ceos").ask()
-                    or "arista/ceos"
-                )
-                result.docker_tag = (
-                    questionary.text("Docker image tag:", default=version).ask()
-                    or version
-                )
-        elif image_format.startswith(VEOS_PREFIX):
-            result.eve_ng = bool(
-                questionary.confirm("Provision EVE-NG?", default=False).ask()
+        # 3. Branch
+        branches = querier.branches(package=package)
+        if not branches:
+            console.print("[red]No branches found for this package.[/red]")
+            return None
+        branch = _ask(questionary.select("Select branch:", choices=branches))
+
+        # 4. Version (newest first)
+        versions = querier.available_public_versions(
+            branch=branch, rtype=rtype, package=package
+        )
+        version_choices = [str(v) for v in sorted(versions, reverse=True)]
+        if not version_choices:
+            console.print(
+                f"[red]No versions found for branch {branch} "
+                f"with the selected criteria.[/red]"
             )
+            return None
+        version = _ask(
+            questionary.select("Select version:", choices=version_choices)
+        )
 
-    # Common options
-    output = questionary.path("Output directory:", default=output_default).ask()
-    result.output = output or output_default
-    result.force = bool(
-        questionary.confirm("Force re-download if cached?", default=False).ask()
-    )
+        result = InteractiveResult(
+            package=package,
+            image_format=image_format,
+            version=version,
+            output=output_default,
+        )
 
-    # 6. Recap + confirmation
-    console.print("\n[bold]Equivalent command:[/bold]")
-    console.print(f"  [cyan]{result.to_command()}[/cyan]\n")
-    if not questionary.confirm("Start download?", default=True).ask():
-        console.print("[yellow]Aborted.[/yellow]")
+        # 5. Format-dependent options (EOS only)
+        if package == "eos":
+            _collect_eos_options(result, image_format, version)
+
+        # Common options
+        output = _ask(
+            questionary.path("Output directory:", default=output_default)
+        )
+        result.output = output or output_default
+        result.force = bool(
+            _ask(questionary.confirm("Force re-download if cached?", default=False))
+        )
+
+        # 6. Recap + confirmation (declining or cancelling aborts)
+        console.print("\n[bold]Equivalent command:[/bold]")
+        console.print(f"  [cyan]{result.to_command()}[/cyan]\n")
+        if not _ask(questionary.confirm("Start download?", default=True)):
+            console.print("[yellow]Aborted.[/yellow]")
+            return None
+    except _Aborted:
         return None
 
     return result
+
+
+def _collect_eos_options(
+    result: InteractiveResult, image_format: str, version: str
+) -> None:
+    """Prompt for the EOS format-dependent options, mutating ``result``.
+
+    Raises
+    ------
+    _Aborted
+        If any prompt is cancelled.
+    """
+    if image_format in CEOS_FORMATS:
+        if _ask(questionary.confirm("Import into Docker?", default=False)):
+            result.import_docker = True
+            result.docker_name = (
+                _ask(questionary.text("Docker image name:", default="arista/ceos"))
+                or "arista/ceos"
+            )
+            result.docker_tag = (
+                _ask(questionary.text("Docker image tag:", default=version))
+                or version
+            )
+    elif image_format.startswith(VEOS_PREFIX):
+        result.eve_ng = bool(
+            _ask(questionary.confirm("Provision EVE-NG?", default=False))
+        )

--- a/eos_downloader/cli/get/interactive.py
+++ b/eos_downloader/cli/get/interactive.py
@@ -1,0 +1,202 @@
+"""Interactive wizard for ``ardl get eos`` / ``ardl get cvp``.
+
+Instead of requiring the user to know every flag value, the wizard presents the
+available choices (format, release type, branch, version) with arrow-key
+selection, offers format-dependent options (Docker import for cEOS, EVE-NG for
+vEOS), and confirms with the equivalent non-interactive command before starting
+the download. The collected parameters are returned so the calling command can
+reuse its normal download path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import questionary
+import typer
+from rich.console import Console
+
+from eos_downloader.models.data import RTYPES, software_mapping
+from eos_downloader.models.types import AristaPackage
+from eos_downloader.logics.arista_xml_server import AristaXmlQuerier
+
+# cEOS container formats that can be imported into Docker.
+CEOS_FORMATS = ("cEOS", "cEOS64", "cEOSarm")
+# Formats that can be provisioned on EVE-NG.
+VEOS_PREFIX = "vEOS"
+
+
+@dataclass
+class InteractiveResult:  # pylint: disable=too-many-instance-attributes
+    """Parameters collected by the interactive wizard."""
+
+    package: str
+    image_format: str
+    version: str
+    output: str
+    force: bool = False
+    import_docker: bool = False
+    docker_name: str = "arista/ceos"
+    docker_tag: Optional[str] = None
+    eve_ng: bool = False
+
+    def to_command(self) -> str:
+        """Render the equivalent non-interactive ``ardl get`` command."""
+        parts: List[str] = [
+            f"ardl get {self.package}",
+            f"--format {self.image_format}",
+            f"--version {self.version}",
+            f"--output {self.output}",
+        ]
+        if self.force:
+            parts.append("--force")
+        if self.import_docker:
+            parts.append("--import-docker")
+            parts.append(f"--docker-name {self.docker_name}")
+            if self.docker_tag:
+                parts.append(f"--docker-tag {self.docker_tag}")
+        if self.eve_ng:
+            parts.append("--eve-ng")
+        return " ".join(parts)
+
+
+def require_interactive_context(console: Console, token: Optional[str]) -> None:
+    """Validate that the interactive wizard can run, or exit with a clear error.
+
+    Parameters
+    ----------
+    console : Console
+        Shared Rich console (its ``is_terminal`` gates the wizard).
+    token : Optional[str]
+        Arista API token; required because the wizard lists branches/versions.
+
+    Raises
+    ------
+    typer.Exit
+        If output is not an interactive terminal, or no token is available.
+    """
+    if not console.is_terminal:
+        console.print(
+            "[red]--interactive requires an interactive terminal (TTY).[/red]"
+        )
+        raise typer.Exit(1)
+    if not token:
+        console.print(
+            "[red]--interactive requires an Arista token "
+            "(set --token or ARISTA_TOKEN).[/red]"
+        )
+        raise typer.Exit(1)
+
+
+def _formats_for(package: AristaPackage) -> List[str]:
+    """Return the selectable image formats for ``package`` (excludes fallbacks)."""
+    mapping = software_mapping.CloudVision if package == "cvp" else software_mapping.EOS
+    return [fmt for fmt in mapping.keys() if fmt != "default"]
+
+
+def run_interactive(
+    package: AristaPackage,
+    console: Console,
+    token: str,
+    output_default: str,
+) -> Optional[InteractiveResult]:
+    """Run the interactive wizard and return the collected parameters.
+
+    Parameters
+    ----------
+    package : AristaPackage
+        The package being downloaded, ``"eos"`` or ``"cvp"``.
+    console : Console
+        Shared Rich console for the recap output.
+    token : str
+        Arista API token (used to list branches and versions).
+    output_default : str
+        Default output directory.
+
+    Returns
+    -------
+    Optional[InteractiveResult]
+        The collected parameters, or ``None`` if the user aborted (Ctrl+C or
+        declined the confirmation, or no versions matched).
+    """
+    querier = AristaXmlQuerier(token=token)
+
+    # 1. Format
+    image_format = questionary.select(
+        "Select image format:", choices=_formats_for(package)
+    ).ask()
+    if image_format is None:
+        return None
+
+    # 2. Release type (EOS only)
+    rtype: Optional[str] = None
+    if package == "eos":
+        rtype = questionary.select("Select release type:", choices=RTYPES).ask()
+        if rtype is None:
+            return None
+
+    # 3. Branch
+    branches = querier.branches(package=package)
+    if not branches:
+        console.print("[red]No branches found for this package.[/red]")
+        return None
+    branch = questionary.select("Select branch:", choices=branches).ask()
+    if branch is None:
+        return None
+
+    # 4. Version (newest first)
+    versions = querier.available_public_versions(
+        branch=branch, rtype=rtype, package=package
+    )
+    version_choices = [str(v) for v in sorted(versions, reverse=True)]
+    if not version_choices:
+        console.print(
+            f"[red]No versions found for branch {branch} "
+            f"with the selected criteria.[/red]"
+        )
+        return None
+    version = questionary.select("Select version:", choices=version_choices).ask()
+    if version is None:
+        return None
+
+    result = InteractiveResult(
+        package=package,
+        image_format=image_format,
+        version=version,
+        output=output_default,
+    )
+
+    # 5. Format-dependent options (EOS only)
+    if package == "eos":
+        if image_format in CEOS_FORMATS:
+            if questionary.confirm("Import into Docker?", default=False).ask():
+                result.import_docker = True
+                result.docker_name = (
+                    questionary.text("Docker image name:", default="arista/ceos").ask()
+                    or "arista/ceos"
+                )
+                result.docker_tag = (
+                    questionary.text("Docker image tag:", default=version).ask()
+                    or version
+                )
+        elif image_format.startswith(VEOS_PREFIX):
+            result.eve_ng = bool(
+                questionary.confirm("Provision EVE-NG?", default=False).ask()
+            )
+
+    # Common options
+    output = questionary.path("Output directory:", default=output_default).ask()
+    result.output = output or output_default
+    result.force = bool(
+        questionary.confirm("Force re-download if cached?", default=False).ask()
+    )
+
+    # 6. Recap + confirmation
+    console.print("\n[bold]Equivalent command:[/bold]")
+    console.print(f"  [cyan]{result.to_command()}[/cyan]\n")
+    if not questionary.confirm("Start download?", default=True).ask():
+        console.print("[yellow]Aborted.[/yellow]")
+        return None
+
+    return result

--- a/openspec/changes/archive/2026-07-19-interactive-download-wizard/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-19-interactive-download-wizard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/archive/2026-07-19-interactive-download-wizard/design.md
+++ b/openspec/changes/archive/2026-07-19-interactive-download-wizard/design.md
@@ -1,0 +1,127 @@
+## Context
+
+`get eos` / `get cvp` are Typer commands whose selection options (`--format`,
+`--release-type`, `--branch`, `--version`, `--latest`) drive
+`search_version()` → `EosXmlObject`/`CvpXmlObject` → `download_files()` and, for
+EOS, optional `--import-docker` / `--eve-ng` handling. Discovering valid values
+today requires prior knowledge or a separate `ardl info` call.
+
+The building blocks the wizard needs already exist:
+- Format lists: `software_mapping.EOS.keys()` and
+  `software_mapping.CloudVision.keys()` (`eos_downloader/models/data.py`).
+- Release types: `RTYPES = ["F", "M"]`.
+- Branches: `AristaXmlQuerier.branches(package=...)` → sorted-desc list.
+- Versions: `AristaXmlQuerier.available_public_versions(branch, rtype, package)`.
+  The querier fetches the XML once at construction, so listing branches then
+  versions parses the in-memory tree — no second network round-trip.
+
+Rich/Typer provide only text prompts, not arrow-key menus, so a dedicated
+prompt library is required.
+
+## Goals / Non-Goals
+
+**Goals:**
+- An opt-in `--interactive` wizard on `get eos` / `get cvp` that collects the
+  same parameters a normal invocation would and then reuses the existing
+  download path.
+- Arrow-key selection for format, release type, branch and version.
+- Format-aware follow-up prompts (Docker for cEOS, EVE-NG for vEOS) plus output
+  directory and a force toggle.
+- A confirmation recap showing the equivalent command.
+
+**Non-Goals:**
+- Changing any non-interactive behaviour.
+- Adding the wizard to `get path` (no version listing there) or to `info`/`debug`.
+- A `--dry-run` prompt inside the wizard.
+- Segmented download or progress changes (separate work).
+
+## Decisions
+
+### 1. `questionary` for arrow-key prompts
+
+Add `questionary` (built on `prompt_toolkit`) as a runtime dependency. It gives
+`select`, `checkbox`, `confirm`, `text` and `path` prompts with arrow-key
+navigation and incremental search, and is cross-platform. Alternatives:
+`InquirerPy` (similar, less maintained), `simple-term-menu` (Unix-only, no
+Windows), `prompt_toolkit` directly (more code). `questionary` is the cleanest
+fit and the "no dependency limitation" constraint is accepted.
+
+### 2. Wizard isolated in `cli/get/interactive.py`
+
+A new module exposes `run_interactive(package, console, token, output_default)`
+returning a small result object / dict of collected parameters
+(`format`, `version`, `import_docker`, `docker_name`, `docker_tag`, `eve_ng`,
+`output`, `force`). `eos()` / `cvp()` call it when `--interactive` is set, apply
+the result, and fall through to the existing flow. This keeps all business
+logic (XML objects, `download_files`, docker/EVE-NG) untouched and unduplicated.
+
+### 3. Package known from the command
+
+`--interactive` lives on each command, so the package (`eos`/`cvp`) is known and
+the wizard starts at the format step. The CVP path skips the release-type step
+and the Docker/EVE-NG prompts (they don't apply). Chosen over a unified
+`get interactive` command because it matches the requested "flag" ergonomics and
+avoids an extra package-selection step.
+
+### 4. Format-driven follow-ups
+
+A mapping classifies the chosen format:
+- `cEOS`, `cEOS64`, `cEOSarm` → offer Docker import; if accepted, prompt image
+  name (default `arista/ceos`) and tag (default = chosen version).
+- `vEOS`, `vEOS-lab`, `vEOS64*` → offer EVE-NG provisioning.
+- everything → output directory (default cwd) + "force re-download?" toggle.
+
+### 5. Branch then version (both newest-first)
+
+The version list is filtered by the chosen branch and release type and sorted
+descending. Requiring a branch first keeps the version list short and readable
+(explicitly no "all branches" escape hatch).
+
+### 6. Guardrails before the wizard opens
+
+`eos()`/`cvp()` validate up front:
+- `--interactive` with `--version`/`--latest`/`--branch` → `typer.BadParameter`.
+- `console.is_terminal` is false → exit with a TTY-required message (reuses the
+  shared console from the progress work).
+- No token → exit before opening the wizard, since branch/version steps hit the
+  API.
+
+### 7. Recap uses the same option names
+
+The confirmation renders the equivalent `ardl get <pkg> --format ... --version
+... [--import-docker ...]` string from the collected parameters, both to confirm
+intent and to teach the flag form. Download proceeds only on confirmation.
+
+## Risks / Trade-offs
+
+- **New dependency (`questionary` + `prompt_toolkit`)** → Accepted per the "no
+  limitation" decision; isolated to the wizard module so the rest of the CLI is
+  unaffected if it is ever swapped.
+- **Version lists can still be long within a branch** → questionary's
+  incremental search mitigates; the branch step already narrows substantially.
+- **Wizard requires network + token mid-flow** → validated up front so failures
+  are clear rather than mid-wizard.
+- **Non-TTY misuse (CI)** → explicit `is_terminal` guard; consistent with the
+  plain/rich reporter selection already in the codebase.
+- **`--format` has a default, so it can't be reliably detected as "explicitly
+  set"** → only `--version`/`--latest`/`--branch` (which default to
+  None/False) are treated as conflicting; `--format` is simply overridden by the
+  wizard.
+
+## Migration Plan
+
+1. Add `questionary` to dependencies.
+2. Add `cli/get/interactive.py` with `run_interactive()` and the format→options
+   mapping.
+3. Add `--interactive` to `eos()` / `cvp()` with the guardrails; wire the result
+   into the existing flow.
+4. Tests (mock `questionary` prompts and the querier) + docs.
+
+Rollback: remove the flag, the module, and the dependency; nothing else depends
+on them.
+
+## Open Questions
+
+- None outstanding — format/branch/version ordering, CVP skipping release type,
+  the force-toggle/no-dry-run choice, and the recap were settled during
+  exploration.

--- a/openspec/changes/archive/2026-07-19-interactive-download-wizard/proposal.md
+++ b/openspec/changes/archive/2026-07-19-interactive-download-wizard/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+Downloading an image with `ardl get eos` / `ardl get cvp` requires the user to
+already know the exact flag values — the image format string, the release type,
+and a valid version — and to type them correctly. New or occasional users don't
+know which formats exist or which versions are available, so they resort to
+trial-and-error or a separate `ardl info` lookup first. A guided, arrow-key
+wizard removes that friction: the tool shows the available choices and the user
+picks, without memorising any flag.
+
+## What Changes
+
+- Add an `--interactive` / `-i` flag to `get eos` and `get cvp`. When set, the
+  command opens a step-by-step wizard instead of reading the other options:
+  1. **Format** — pick from the formats available for the package
+     (`software_mapping.EOS` / `CloudVision`).
+  2. **Release type** — pick `F` or `M`. **Skipped for CVP.**
+  3. **Branch** — pick one branch from the available branches (sorted, newest
+     first).
+  4. **Version** — pick one version from the versions of that branch (sorted,
+     newest first).
+  5. **Format-dependent options**:
+     - `cEOS*` → offer Docker import (then Docker image name + tag).
+     - `vEOS*` → offer EVE-NG provisioning.
+     - all formats → ask the output directory and a "force re-download" toggle.
+  6. **Recap** — show the equivalent non-interactive command and ask for
+     confirmation before starting the download.
+- Selections use arrow-key navigation via a new `questionary` dependency.
+- The wizard reuses the existing download path (`EosXmlObject` / `CvpXmlObject`,
+  `download_files`, docker/EVE-NG handling) — no business logic is duplicated.
+- Guardrails:
+  - `--interactive` requires an interactive terminal (TTY); otherwise it exits
+    with a clear error.
+  - A token must be available before the wizard starts (branch/version steps
+    query the Arista API); otherwise it exits with a clear error.
+  - `--interactive` combined with `--version`, `--latest`, or `--branch` is
+    rejected with a `BadParameter` error (they are mutually exclusive).
+  - `--dry-run` is intentionally not offered in the wizard.
+
+## Capabilities
+
+### New Capabilities
+- `interactive-download`: The `--interactive` wizard for `get eos` / `get cvp` —
+  its steps, per-package differences (CVP skips release type), format-dependent
+  option prompts, the confirmation recap, and the TTY/token/mutual-exclusion
+  guardrails.
+
+### Modified Capabilities
+<!-- None: the non-interactive get commands keep their current behaviour; the
+     wizard is purely additive. -->
+
+## Impact
+
+- **Code**
+  - New `eos_downloader/cli/get/interactive.py` — the wizard
+    (`run_interactive(...)` returning the collected parameters).
+  - `eos_downloader/cli/get/commands.py` — add `--interactive` to `eos()` and
+    `cvp()`; when set, run the wizard, then continue the existing flow.
+  - `eos_downloader/models/data.py` — reuse `software_mapping` keys for the
+    format list (read-only).
+- **Dependencies**: add `questionary` (arrow-key prompts; pulls in
+  `prompt_toolkit`).
+- **Behavior**: non-interactive usage is unchanged; `--interactive` is an
+  additive, opt-in entry point.

--- a/openspec/changes/archive/2026-07-19-interactive-download-wizard/specs/interactive-download/spec.md
+++ b/openspec/changes/archive/2026-07-19-interactive-download-wizard/specs/interactive-download/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: Interactive flag on the get commands
+
+`get eos` and `get cvp` SHALL accept an `--interactive` / `-i` flag that opens a
+guided wizard to collect the download parameters instead of reading the other
+selection options.
+
+#### Scenario: Interactive flag opens the wizard
+- **WHEN** `ardl get eos --interactive` is run in an interactive terminal with a
+  valid token
+- **THEN** a step-by-step wizard is presented instead of downloading directly
+  from CLI-provided options
+
+#### Scenario: Non-interactive usage is unchanged
+- **WHEN** `get eos` / `get cvp` is run without `--interactive`
+- **THEN** the command behaves exactly as before, reading its options from the
+  CLI
+
+### Requirement: Wizard step sequence
+
+The wizard SHALL guide the user through, in order: format, release type (EOS
+only), branch, version, and format-dependent options, each selected with
+arrow-key navigation.
+
+#### Scenario: EOS wizard steps
+- **WHEN** the wizard runs for `get eos`
+- **THEN** the user selects, in order, a format, a release type (`F`/`M`), a
+  branch, a version, and any format-dependent options
+
+#### Scenario: CVP wizard skips release type
+- **WHEN** the wizard runs for `get cvp`
+- **THEN** the release-type step is not presented
+- **AND** the remaining steps (format, branch, version, options) are presented
+
+#### Scenario: Format list comes from the package mapping
+- **WHEN** the format step is presented
+- **THEN** the choices are the formats available for the package (EOS or CVP)
+  from the software mapping
+
+### Requirement: Branch-narrowed version selection
+
+The wizard SHALL present branches sorted newest-first, require the user to pick
+exactly one branch, then present the versions of that branch sorted newest-first
+for selection.
+
+#### Scenario: Branch then version
+- **WHEN** the user reaches the branch step
+- **THEN** the available branches are listed newest-first and the user picks one
+- **AND** the version step then lists only that branch's versions, newest-first
+
+#### Scenario: Release type filters the versions
+- **WHEN** an EOS release type has been chosen
+- **THEN** the version list is limited to versions of that release type
+
+### Requirement: Format-dependent option prompts
+
+After the version is chosen, the wizard SHALL offer additional prompts based on
+the selected format, and SHALL always ask for the output directory and a
+force-re-download toggle.
+
+#### Scenario: cEOS offers Docker import
+- **WHEN** the selected format is a `cEOS` variant (`cEOS`, `cEOS64`, `cEOSarm`)
+- **THEN** the wizard offers to import the image into Docker
+- **AND** when accepted, prompts for the Docker image name and tag
+
+#### Scenario: vEOS offers EVE-NG provisioning
+- **WHEN** the selected format is a `vEOS` variant
+- **THEN** the wizard offers EVE-NG provisioning
+
+#### Scenario: Common options always asked
+- **WHEN** any format is selected
+- **THEN** the wizard asks for the output directory (default: current directory)
+- **AND** asks whether to force a re-download
+
+#### Scenario: Dry-run is not offered
+- **WHEN** the wizard runs
+- **THEN** no dry-run option is presented
+
+### Requirement: Confirmation recap
+
+Before starting the download the wizard SHALL display the equivalent
+non-interactive command built from the selections and ask the user to confirm.
+
+#### Scenario: Confirm before download
+- **WHEN** all selections are made
+- **THEN** the wizard shows the equivalent `ardl get ...` command
+- **AND** starts the download only after the user confirms
+
+#### Scenario: Declining aborts without downloading
+- **WHEN** the user declines the confirmation
+- **THEN** no download is performed and the command exits
+
+### Requirement: Interactive guardrails
+
+The wizard SHALL be usable only in a valid context: an interactive terminal, an
+available token, and no conflicting selection options.
+
+#### Scenario: Requires an interactive terminal
+- **WHEN** `--interactive` is used but output is not an interactive terminal
+  (piped, redirected, CI)
+- **THEN** the command exits with a clear error explaining a TTY is required
+
+#### Scenario: Requires a token
+- **WHEN** `--interactive` is used without an available token
+- **THEN** the command exits with a clear error before opening the wizard
+
+#### Scenario: Mutually exclusive with explicit selection options
+- **WHEN** `--interactive` is combined with `--version`, `--latest`, or
+  `--branch`
+- **THEN** the command fails with a `BadParameter` error

--- a/openspec/changes/archive/2026-07-19-interactive-download-wizard/tasks.md
+++ b/openspec/changes/archive/2026-07-19-interactive-download-wizard/tasks.md
@@ -1,0 +1,30 @@
+## 1. Dependency
+
+- [x] 1.1 Add `questionary` to `pyproject.toml` runtime dependencies and update `uv.lock`
+
+## 2. Wizard module
+
+- [x] 2.1 Create `eos_downloader/cli/get/interactive.py` with a `run_interactive(package, console, token, output_default)` entry point returning the collected parameters
+- [x] 2.2 Format step: arrow-key select from `software_mapping.EOS.keys()` / `CloudVision.keys()` for the package
+- [x] 2.3 Release-type step: select `F`/`M` for EOS; skip entirely for CVP
+- [x] 2.4 Branch step: select one branch from `AristaXmlQuerier.branches(package)` (newest-first)
+- [x] 2.5 Version step: select one version from `available_public_versions(branch, rtype, package)` (newest-first)
+- [x] 2.6 Format-dependent options: `cEOS*` → Docker import (+ name default `arista/ceos`, tag default = version); `vEOS*` → EVE-NG toggle
+- [x] 2.7 Common options: output directory (default cwd) and a force-re-download toggle; no dry-run prompt
+- [x] 2.8 Build and display the equivalent `ardl get <pkg> ...` command, then a confirmation prompt; abort cleanly if declined
+
+## 3. Command integration
+
+- [x] 3.1 Add `--interactive` / `-i` flag to `get eos` and `get cvp`
+- [x] 3.2 On `--interactive`, validate guardrails: reject combination with `--version`/`--latest`/`--branch` (`typer.BadParameter`); require `console.is_terminal`; require a token — each with a clear message
+- [x] 3.3 Run `run_interactive()`, apply the returned parameters, and continue the existing download flow (`EosXmlObject`/`CvpXmlObject` → `download_files`, plus Docker/EVE-NG for EOS)
+
+## 4. Tests & docs
+
+- [x] 4.1 Test the format→options mapping (cEOS→docker, vEOS→eve-ng, others→none)
+- [x] 4.2 Test CVP skips the release-type step
+- [x] 4.3 Test guardrails: non-TTY error, missing-token error, mutual-exclusion `BadParameter`
+- [x] 4.4 Test the wizard end-to-end with mocked `questionary` prompts and a mocked querier, asserting the resulting parameters and that decline aborts
+- [x] 4.5 Test that the recap renders the correct equivalent command
+- [x] 4.6 Update docs/CLI help for `--interactive`
+- [x] 4.7 Run `make check` (lint + type + test) and fix findings

--- a/openspec/specs/interactive-download/spec.md
+++ b/openspec/specs/interactive-download/spec.md
@@ -1,0 +1,114 @@
+# interactive-download Specification
+
+## Purpose
+Define the `--interactive` wizard for `ardl get eos` / `ardl get cvp`: its step sequence, the per-package differences (CVP has no release type), the format-dependent option prompts, the confirmation recap showing the equivalent command, and the terminal/token/mutual-exclusion guardrails.
+## Requirements
+### Requirement: Interactive flag on the get commands
+
+`get eos` and `get cvp` SHALL accept an `--interactive` / `-i` flag that opens a
+guided wizard to collect the download parameters instead of reading the other
+selection options.
+
+#### Scenario: Interactive flag opens the wizard
+- **WHEN** `ardl get eos --interactive` is run in an interactive terminal with a
+  valid token
+- **THEN** a step-by-step wizard is presented instead of downloading directly
+  from CLI-provided options
+
+#### Scenario: Non-interactive usage is unchanged
+- **WHEN** `get eos` / `get cvp` is run without `--interactive`
+- **THEN** the command behaves exactly as before, reading its options from the
+  CLI
+
+### Requirement: Wizard step sequence
+
+The wizard SHALL guide the user through, in order: format, release type (EOS
+only), branch, version, and format-dependent options, each selected with
+arrow-key navigation.
+
+#### Scenario: EOS wizard steps
+- **WHEN** the wizard runs for `get eos`
+- **THEN** the user selects, in order, a format, a release type (`F`/`M`), a
+  branch, a version, and any format-dependent options
+
+#### Scenario: CVP wizard skips release type
+- **WHEN** the wizard runs for `get cvp`
+- **THEN** the release-type step is not presented
+- **AND** the remaining steps (format, branch, version, options) are presented
+
+#### Scenario: Format list comes from the package mapping
+- **WHEN** the format step is presented
+- **THEN** the choices are the formats available for the package (EOS or CVP)
+  from the software mapping
+
+### Requirement: Branch-narrowed version selection
+
+The wizard SHALL present branches sorted newest-first, require the user to pick
+exactly one branch, then present the versions of that branch sorted newest-first
+for selection.
+
+#### Scenario: Branch then version
+- **WHEN** the user reaches the branch step
+- **THEN** the available branches are listed newest-first and the user picks one
+- **AND** the version step then lists only that branch's versions, newest-first
+
+#### Scenario: Release type filters the versions
+- **WHEN** an EOS release type has been chosen
+- **THEN** the version list is limited to versions of that release type
+
+### Requirement: Format-dependent option prompts
+
+After the version is chosen, the wizard SHALL offer additional prompts based on
+the selected format, and SHALL always ask for the output directory and a
+force-re-download toggle.
+
+#### Scenario: cEOS offers Docker import
+- **WHEN** the selected format is a `cEOS` variant (`cEOS`, `cEOS64`, `cEOSarm`)
+- **THEN** the wizard offers to import the image into Docker
+- **AND** when accepted, prompts for the Docker image name and tag
+
+#### Scenario: vEOS offers EVE-NG provisioning
+- **WHEN** the selected format is a `vEOS` variant
+- **THEN** the wizard offers EVE-NG provisioning
+
+#### Scenario: Common options always asked
+- **WHEN** any format is selected
+- **THEN** the wizard asks for the output directory (default: current directory)
+- **AND** asks whether to force a re-download
+
+#### Scenario: Dry-run is not offered
+- **WHEN** the wizard runs
+- **THEN** no dry-run option is presented
+
+### Requirement: Confirmation recap
+
+Before starting the download the wizard SHALL display the equivalent
+non-interactive command built from the selections and ask the user to confirm.
+
+#### Scenario: Confirm before download
+- **WHEN** all selections are made
+- **THEN** the wizard shows the equivalent `ardl get ...` command
+- **AND** starts the download only after the user confirms
+
+#### Scenario: Declining aborts without downloading
+- **WHEN** the user declines the confirmation
+- **THEN** no download is performed and the command exits
+
+### Requirement: Interactive guardrails
+
+The wizard SHALL be usable only in a valid context: an interactive terminal, an
+available token, and no conflicting selection options.
+
+#### Scenario: Requires an interactive terminal
+- **WHEN** `--interactive` is used but output is not an interactive terminal
+  (piped, redirected, CI)
+- **THEN** the command exits with a clear error explaining a TTY is required
+
+#### Scenario: Requires a token
+- **WHEN** `--interactive` is used without an available token
+- **THEN** the command exits with a clear error before opening the wizard
+
+#### Scenario: Mutually exclusive with explicit selection options
+- **WHEN** `--interactive` is combined with `--version`, `--latest`, or
+  `--branch`
+- **THEN** the command fails with a `BadParameter` error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "rich>=13.5.2",
   "cvprac>=1.0.7",
   "typer>=0.12.0",
+  "questionary>=2.0.0",
   "pydantic>2.0.0",
   "urllib3>=2.2.2",
   "pyyaml>=6.0",

--- a/tests/unit/cli/test_interactive.py
+++ b/tests/unit/cli/test_interactive.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python
+# coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+# pylint: disable=protected-access
+
+"""Tests for the interactive download wizard (cli/get/interactive.py)."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import Any, Dict, List
+from unittest.mock import Mock, patch
+
+import pytest
+import typer
+from rich.console import Console
+from typer.testing import CliRunner
+
+from eos_downloader.cli.cli import app
+from eos_downloader.cli.get import interactive as interactive_module
+from eos_downloader.cli.get.interactive import (
+    InteractiveResult,
+    _formats_for,
+    require_interactive_context,
+    run_interactive,
+)
+from eos_downloader.models.version import EosVersion
+
+
+def _ans(value: Any) -> Mock:
+    """Build a fake questionary prompt whose ``.ask()`` returns ``value``."""
+    prompt = Mock()
+    prompt.ask.return_value = value
+    return prompt
+
+
+class TestFormats:
+    """_formats_for returns package-specific formats without the fallback."""
+
+    def test_eos_excludes_default(self) -> None:
+        formats = _formats_for("eos")
+        assert "default" not in formats
+        assert "cEOS" in formats and "vEOS-lab" in formats
+
+    def test_cvp_formats(self) -> None:
+        assert set(_formats_for("cvp")) == {"ova", "rpm", "kvm", "atswi", "upgrade"}
+
+
+class TestToCommand:
+    """InteractiveResult.to_command renders the equivalent CLI command."""
+
+    def test_plain(self) -> None:
+        result = InteractiveResult(
+            package="cvp", image_format="ova", version="2024.3.0", output="/tmp"
+        )
+        assert result.to_command() == (
+            "ardl get cvp --format ova --version 2024.3.0 --output /tmp"
+        )
+
+    def test_ceos_with_docker(self) -> None:
+        result = InteractiveResult(
+            package="eos",
+            image_format="cEOS",
+            version="4.29.3M",
+            output=".",
+            force=True,
+            import_docker=True,
+            docker_name="arista/ceos",
+            docker_tag="4.29.3M",
+        )
+        cmd = result.to_command()
+        assert "--force" in cmd
+        assert "--import-docker" in cmd
+        assert "--docker-name arista/ceos" in cmd
+        assert "--docker-tag 4.29.3M" in cmd
+
+    def test_veos_with_eve_ng(self) -> None:
+        result = InteractiveResult(
+            package="eos",
+            image_format="vEOS-lab",
+            version="4.29.3M",
+            output=".",
+            eve_ng=True,
+        )
+        assert "--eve-ng" in result.to_command()
+
+
+class TestRequireInteractiveContext:
+    """The wizard only runs with a TTY and a token."""
+
+    def test_non_terminal_exits(self) -> None:
+        console = Console(force_terminal=False)
+        with pytest.raises(typer.Exit):
+            require_interactive_context(console, "token")
+
+    def test_missing_token_exits(self) -> None:
+        console = Console(force_terminal=True)
+        with pytest.raises(typer.Exit):
+            require_interactive_context(console, None)
+
+    def test_valid_context_passes(self) -> None:
+        console = Console(force_terminal=True)
+        require_interactive_context(console, "token")  # no raise
+
+
+def _patch_questionary(
+    *,
+    selects: List[Any],
+    confirms: List[Any],
+    texts: List[Any],
+    paths: List[Any],
+) -> ExitStack:
+    """Patch questionary prompts with sequenced answers; return an ExitStack."""
+    stack = ExitStack()
+    stack.enter_context(
+        patch.object(
+            interactive_module.questionary,
+            "select",
+            side_effect=[_ans(v) for v in selects],
+        )
+    )
+    stack.enter_context(
+        patch.object(
+            interactive_module.questionary,
+            "confirm",
+            side_effect=[_ans(v) for v in confirms],
+        )
+    )
+    stack.enter_context(
+        patch.object(
+            interactive_module.questionary,
+            "text",
+            side_effect=[_ans(v) for v in texts],
+        )
+    )
+    stack.enter_context(
+        patch.object(
+            interactive_module.questionary,
+            "path",
+            side_effect=[_ans(v) for v in paths],
+        )
+    )
+    return stack
+
+
+def _mock_querier(branches: List[str], versions: List[EosVersion]) -> Mock:
+    """Build a mock AristaXmlQuerier."""
+    querier = Mock()
+    querier.branches.return_value = branches
+    querier.available_public_versions.return_value = versions
+    return querier
+
+
+class TestRunInteractive:
+    """End-to-end wizard flow with mocked prompts and querier."""
+
+    @pytest.fixture
+    def console(self) -> Console:
+        return Console(force_terminal=True)
+
+    def test_eos_ceos_flow_with_docker(self, console: Console) -> None:
+        versions = [EosVersion.from_str("4.29.3M"), EosVersion.from_str("4.29.1M")]
+        querier = _mock_querier(["4.29", "4.28"], versions)
+        with patch.object(interactive_module, "AristaXmlQuerier", return_value=querier):
+            with _patch_questionary(
+                selects=["cEOS", "M", "4.29", "4.29.3M"],
+                confirms=[True, False, True],  # docker?, force?, start?
+                texts=["arista/ceos", "4.29.3M"],  # docker name, tag
+                paths=["/downloads"],
+            ):
+                result = run_interactive("eos", console, "token", ".")
+
+        assert result is not None
+        assert result.image_format == "cEOS"
+        assert result.version == "4.29.3M"
+        assert result.output == "/downloads"
+        assert result.import_docker is True
+        assert result.docker_tag == "4.29.3M"
+        assert result.eve_ng is False
+        querier.available_public_versions.assert_called_once_with(
+            branch="4.29", rtype="M", package="eos"
+        )
+
+    def test_cvp_skips_release_type(self, console: Console) -> None:
+        versions = [EosVersion.from_str("2024.3.0")]
+        querier = _mock_querier(["2024.3"], versions)
+        with patch.object(interactive_module, "AristaXmlQuerier", return_value=querier):
+            with _patch_questionary(
+                selects=["ova", "2024.3", "2024.3.0"],  # NO release-type select
+                confirms=[False, True],  # force?, start?
+                texts=[],
+                paths=["."],
+            ) as stack:
+                select_mock = interactive_module.questionary.select
+                result = run_interactive("cvp", console, "token", ".")
+                prompts = [call.args[0] for call in select_mock.call_args_list]
+
+        assert result is not None
+        assert "Select release type:" not in prompts
+        assert prompts == [
+            "Select image format:",
+            "Select branch:",
+            "Select version:",
+        ]
+        # CVP never queries with a release type.
+        querier.available_public_versions.assert_called_once_with(
+            branch="2024.3", rtype=None, package="cvp"
+        )
+
+    def test_decline_confirmation_aborts(self, console: Console) -> None:
+        versions = [EosVersion.from_str("4.29.3M")]
+        querier = _mock_querier(["4.29"], versions)
+        with patch.object(interactive_module, "AristaXmlQuerier", return_value=querier):
+            with _patch_questionary(
+                selects=["64", "F", "4.29", "4.29.3M"],
+                confirms=[False, False],  # force?, start? -> declined
+                texts=[],
+                paths=["."],
+            ):
+                result = run_interactive("eos", console, "token", ".")
+
+        assert result is None
+
+    def test_abort_on_format_step(self, console: Console) -> None:
+        querier = _mock_querier(["4.29"], [])
+        with patch.object(interactive_module, "AristaXmlQuerier", return_value=querier):
+            with _patch_questionary(
+                selects=[None],  # user hit Ctrl+C at the format step
+                confirms=[],
+                texts=[],
+                paths=[],
+            ):
+                result = run_interactive("eos", console, "token", ".")
+
+        assert result is None
+
+
+class TestInteractiveGuardrails:
+    """Command-level guardrails for --interactive."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_context(self) -> Dict[str, Any]:
+        return {"token": "test-token", "log_level": "info", "debug": False}
+
+    @patch("eos_downloader.cli.get.commands.initialize")
+    def test_mutually_exclusive_with_version(
+        self, mock_init: Mock, runner: CliRunner, mock_context: Dict[str, Any]
+    ) -> None:
+        mock_init.return_value = (Console(force_terminal=True), "token", False, "info")
+        result = runner.invoke(
+            app,
+            ["get", "eos", "--interactive", "--version", "4.29.3M"],
+            obj=mock_context,
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    @patch("eos_downloader.cli.get.commands.initialize")
+    def test_non_tty_exits(
+        self, mock_init: Mock, runner: CliRunner, mock_context: Dict[str, Any]
+    ) -> None:
+        mock_init.return_value = (Console(force_terminal=False), "token", False, "info")
+        result = runner.invoke(app, ["get", "eos", "--interactive"], obj=mock_context)
+        assert result.exit_code == 1
+        assert "terminal" in result.output.lower()

--- a/tests/unit/cli/test_interactive.py
+++ b/tests/unit/cli/test_interactive.py
@@ -24,7 +24,7 @@ from eos_downloader.cli.get.interactive import (
     require_interactive_context,
     run_interactive,
 )
-from eos_downloader.models.version import EosVersion
+from eos_downloader.models.version import CvpVersion, EosVersion
 
 
 def _ans(value: Any) -> Mock:
@@ -143,7 +143,7 @@ def _patch_questionary(
     return stack
 
 
-def _mock_querier(branches: List[str], versions: List[EosVersion]) -> Mock:
+def _mock_querier(branches: List[str], versions: List[Any]) -> Mock:
     """Build a mock AristaXmlQuerier."""
     querier = Mock()
     querier.branches.return_value = branches
@@ -182,7 +182,7 @@ class TestRunInteractive:
         )
 
     def test_cvp_skips_release_type(self, console: Console) -> None:
-        versions = [EosVersion.from_str("2024.3.0")]
+        versions = [CvpVersion.from_str("2024.3.0")]
         querier = _mock_querier(["2024.3"], versions)
         with patch.object(interactive_module, "AristaXmlQuerier", return_value=querier):
             with _patch_questionary(
@@ -227,6 +227,32 @@ class TestRunInteractive:
             with _patch_questionary(
                 selects=[None],  # user hit Ctrl+C at the format step
                 confirms=[],
+                texts=[],
+                paths=[],
+            ):
+                result = run_interactive("eos", console, "token", ".")
+
+        assert result is None
+
+    def test_cancel_output_prompt_aborts(self, console: Console) -> None:
+        querier = _mock_querier(["4.29"], [EosVersion.from_str("4.29.3M")])
+        with patch.object(interactive_module, "AristaXmlQuerier", return_value=querier):
+            with _patch_questionary(
+                selects=["64", "F", "4.29", "4.29.3M"],
+                confirms=[],
+                texts=[],
+                paths=[None],  # Ctrl+C at the output-directory prompt
+            ):
+                result = run_interactive("eos", console, "token", ".")
+
+        assert result is None
+
+    def test_cancel_docker_confirm_aborts(self, console: Console) -> None:
+        querier = _mock_querier(["4.29"], [EosVersion.from_str("4.29.3M")])
+        with patch.object(interactive_module, "AristaXmlQuerier", return_value=querier):
+            with _patch_questionary(
+                selects=["cEOS", "M", "4.29", "4.29.3M"],
+                confirms=[None],  # Ctrl+C at the "Import into Docker?" prompt
                 texts=[],
                 paths=[],
             ):

--- a/uv.lock
+++ b/uv.lock
@@ -636,6 +636,7 @@ dependencies = [
     { name = "paramiko" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "questionary" },
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "rich" },
@@ -731,6 +732,7 @@ requires-dist = [
     { name = "pytest-html", marker = "extra == 'dev'", specifier = ">=3.1.1" },
     { name = "pytest-metadata", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "questionary", specifier = ">=2.0.0" },
     { name = "requests", specifier = ">=2.20.0" },
     { name = "requests-toolbelt" },
     { name = "responses", marker = "extra == 'dev'", specifier = ">=0.25.0" },
@@ -1396,6 +1398,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1879,6 +1893,18 @@ wheels = [
 ]
 
 [[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2277,6 +2303,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Downloading with `ardl get eos` / `ardl get cvp` requires the user to already
know the exact format string, release type and a valid version. New or
occasional users don't know which formats/versions exist and resort to
trial-and-error or a separate `ardl info` lookup. This PR adds an opt-in,
arrow-key wizard that shows the available choices instead.

## What changes

Add an `--interactive` / `-i` flag to `get eos` and `get cvp`. When set, a
guided wizard collects the parameters instead of reading the other options:

1. **Format** — pick from the formats available for the package.
2. **Release type** — pick `F`/`M` (**skipped for CVP**).
3. **Branch** — pick one branch (newest-first).
4. **Version** — pick one version of that branch (newest-first); the branch step
   keeps the list short and readable.
5. **Format-dependent options**:
   - `cEOS*` → offer Docker import (+ image name/tag).
   - `vEOS*` → offer EVE-NG provisioning.
   - all formats → output directory + a force-re-download toggle.
6. **Recap** — show the equivalent `ardl get ...` command and confirm before
   downloading.

Selections use arrow-key navigation via the new `questionary` dependency. The
wizard (new `cli/get/interactive.py`) only collects parameters and reuses the
existing download path — no business logic is duplicated.

### Guardrails
- Requires an interactive terminal (TTY); errors clearly otherwise.
- Requires a token before opening (branch/version steps hit the API).
- Mutually exclusive with `--version` / `--latest` / `--branch` (`BadParameter`).
- `--dry-run` is intentionally not offered.

## Testing
- 14 new unit tests (`tests/unit/cli/test_interactive.py`): format→options
  mapping, `to_command` recap, CVP skipping the release-type step, full flow
  with mocked prompts + querier, decline/abort paths, and the TTY/token/mutual-
  exclusion guardrails.
- `make check` green: 469 tests, lint 10/10, mypy clean.

## Docs
- New "Interactive mode" sections in `docs/usage/eos.md` and `docs/usage/cvp.md`.
- Updated help snapshots in both pages (also backfilled the missing
  `--no-progress` entries).
- README: new "Interactive Mode" key feature + example; `docs/README.md` example.

## Notes
- New runtime dependency: `questionary` (pulls in `prompt_toolkit`).
- Non-interactive usage is unchanged; the flag is purely additive.
- Planned as a separate follow-up: intra-file segmented/multi-connection
  download (the real single-file speed-up).
